### PR TITLE
fix: insecure websocket connection

### DIFF
--- a/client/composables/rpc.ts
+++ b/client/composables/rpc.ts
@@ -24,7 +24,11 @@ export const rpc = createBirpc<ServerFunctions>(clientFunctions, {
 })
 
 async function connectWS() {
-  const ws = new WebSocket(`ws://${location.host}/__nuxt_devtools__/entry`)
+  const wsUrl = new URL('ws://host/__nuxt_devtools__/entry')
+  wsUrl.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  wsUrl.host = location.host
+
+  const ws = new WebSocket(wsUrl.toString())
   ws.addEventListener('message', e => onMessage(String(e.data)))
   ws.addEventListener('error', (e) => {
     wsError.value = e


### PR DESCRIPTION
Devtools didn't work in my local dev setup on a secure url, as it attempts to connect over `ws:` instead of `wss:`.