### PR TITLE
docs: module options

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,3 +8,5 @@
     "vue/no-v-text-v-html-on-component": "off"
   }
 }
+
+

--- a/README.md
+++ b/README.md
@@ -79,24 +79,26 @@ Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and rein
 
 
 ### Module Options
+
+To configure Nuxt DevTools, you can pass the `devtools` options. 
+
 ```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
   modules: [
-    ['@nuxt/devtools', {
-      enabled: true, // Enable devtools (default: true)
-      vscode: {
-        enabled: true, // Enable VS Code Server integration
-        startOnBoot: false, // Start VS Code Server on boot (default: false)
-        port: 8080, // VS Code Server port (default: 3080)
-        reuseExistingServer: true // Reuse existing VS Code Server instance
-      }
-    }
-    ]
-  ]
+    '@nuxt/devtools',
+  ],
+  devtools: {
+    // Enable devtools (default: true)
+    enabled: true,
+    // VS Code Server options
+    vscode: {},
+    // ...other options
+  }
 })
 ```
 
+For all options available, please refer to TSDocs in your IDE, or the [type definition file](https://github.com/nuxt/devtools/blob/main/src/types.ts#L11).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ const router = computed(() => devtoolsClient.value?.host?.nuxt.vueApp.config.glo
 - VueUse adds a docs tab: https://github.com/vueuse/vueuse/blob/6158e660367b4417896926984670c5b91133c7c3/packages/nuxt/index.ts#L89-L99.
 - UnoCSS Inspector: https://github.com/unocss/unocss/blob/25021a751494e99e85cfd82cca3855cdf78f6a12/packages/nuxt/src/index.ts#L81-L94
 - Nuxt Vitest runner: https://github.com/danielroe/nuxt-vitest/blob/7bac68d96f27dea6c30c198b7caaaf0b495574ab/packages/nuxt-vitest/src/module.ts#L139-L181
+- Nuxt OG Image Playground: https://github.com/harlan-zw/nuxt-og-image/blob/main/src/module.ts#L136
 
 ## License
 

--- a/src/integrations/vscode.ts
+++ b/src/integrations/vscode.ts
@@ -1,3 +1,4 @@
+import { hostname } from 'os'
 import { logger } from '@nuxt/kit'
 import { execa } from 'execa'
 import type { Nuxt } from '@nuxt/schema'
@@ -9,13 +10,16 @@ import { LOG_PREFIX } from '../logger'
 
 export async function setup(nuxt: Nuxt, _functions: ServerFunctions, options: VSCodeIntegrationOptions) {
   const installed = !!await which('code-server').catch(() => null)
+  const installedCode = !!await which('code').catch(() => null)
 
   let port = options?.port || 3080
   let url = `http://localhost:${port}`
   let loaded = false
   let promise: Promise<void> | null = null
+  const medium = options?.medium || 'tunnel'
+  const computerHostName = options.tunnel?.name || hostname().split('.').join('')
 
-  async function start() {
+  async function startCodeServer() {
     if (options?.reuseExistingServer && !(await checkPort(port))) {
       loaded = true
       url = `http://localhost:${port}/?folder=${encodeURIComponent(nuxt.options.rootDir)}`
@@ -27,6 +31,7 @@ export async function setup(nuxt: Nuxt, _functions: ServerFunctions, options: VS
     url = `http://localhost:${port}/?folder=${encodeURIComponent(nuxt.options.rootDir)}`
 
     logger.info(LOG_PREFIX, `Starting VS Code Server at ${url} ...`)
+
     const command = execa('code-server', [
       'serve-local',
       '--accept-server-license-terms',
@@ -48,7 +53,47 @@ export async function setup(nuxt: Nuxt, _functions: ServerFunctions, options: VS
     loaded = true
   }
 
+  async function startCodeTunnel() {
+    const { stdout: currentDir } = await execa('pwd')
+
+    url = `https://vscode.dev/tunnel/${computerHostName}${currentDir}`
+    // url = 'https://vscode.dev/tunnel/cruxlocal/Users/claranceliberi/projects/mine/devtools'
+
+    const command = execa('code', [
+      'tunnel',
+      '--accept-server-license-terms',
+      '--name',
+      `${computerHostName}`,
+    ])
+
+    command.stderr?.pipe(process.stderr)
+    command.stdout?.pipe(process.stdout)
+
+    nuxt.hook('close', () => {
+      command.kill()
+    })
+
+    await waitOn({
+      resources: [`${url}/healthz`],
+      timeout: 20_000,
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 2000))
+    loaded = true
+    console.log('loaded', url)
+  }
+
+  async function start() {
+    if (medium === 'server') {
+      await startCodeServer()
+      return
+    }
+
+    await startCodeTunnel()
+  }
+
   nuxt.hook('devtools:customTabs', (tabs) => {
+    logger.info(LOG_PREFIX, `Adding VS Code tab... ${url}`)
     tabs.push({
       name: 'builtin-vscode',
       title: 'VS Code',

--- a/src/integrations/vscode.ts
+++ b/src/integrations/vscode.ts
@@ -74,13 +74,12 @@ export async function setup(nuxt: Nuxt, _functions: ServerFunctions, options: VS
     })
 
     await waitOn({
-      resources: [`${url}/healthz`],
+      resources: [url],
       timeout: 20_000,
     })
 
     await new Promise(resolve => setTimeout(resolve, 2000))
     loaded = true
-    console.log('loaded', url)
   }
 
   async function start() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,4 +337,25 @@ export interface VSCodeIntegrationOptions {
    * Reuse existing server if available (same port)
    */
   reuseExistingServer?: boolean
+
+  /**
+   * Determine whether to use vs code tunnel or code-server
+   *
+   * @default 'tunnel'
+   */
+  medium?: 'tunnel' | 'server'
+
+  /**
+   * Options for VS Code tunnel
+   */
+  tunnel?: VSCodeTunnelOptions
+}
+
+export interface VSCodeTunnelOptions {
+  /**
+   * the machine name for port forwarding service
+   *
+   * default: device hostname
+   */
+  name?: string
 }


### PR DESCRIPTION
Since `code-server` is having kinda random ports, I added this in docs for people to easily figure out that they can change the code-server listening port for this project