### PR TITLE
refactor: remove obsolete cursor pointer def

### DIFF
--- a/client/components/ModuleItem.vue
+++ b/client/components/ModuleItem.vue
@@ -48,7 +48,6 @@ const npmBase = 'https://www.npmjs.com/package/'
         </NuxtLink>
         <button
           v-else-if="mod.entryPath"
-          cursor-pointer
           role="button"
           hover="underline text-primary"
           @click="rpc.openInEditor(mod.entryPath!)"


### PR DESCRIPTION
Follow-up of #51. The explicit `cursor-pointer` attr is not needed for a `<button>` ☺️