### PR TITLE
feat(client): allow file column resize in VFS

### DIFF
--- a/client/pages/modules/virtual-files.vue
+++ b/client/pages/modules/virtual-files.vue
@@ -72,8 +72,8 @@ const filteredFiles = computed(() => {
 </script>
 
 <template>
-  <div grid="~ cols-[300px_1fr]" h-full of-hidden class="virtual-files">
-    <div border="r base" of-auto>
+  <div grid="~ cols-[auto_1fr]" h-full of-hidden class="virtual-files">
+    <div border="r base" of-auto resize-x w="300px">
       <div pb2 p3>
         <NTextInput
           v-model="searchString"


### PR DESCRIPTION
HI :wave: small UI improvement in the VFS part.
A lot of file path are quite long and are hidden since it does not have enough space to show up. 
This PR adds the CSS `resize` property to give us the ability to resize the file path column

![image](https://user-images.githubusercontent.com/63512348/219942743-1dc63e0c-2665-46c3-b135-b0e521edbc59.png)
![image](https://user-images.githubusercontent.com/63512348/219942765-176d1344-fb9e-4b5d-8464-ff55ea079c01.png)
