### PR TITLE
fix(ui): fix unexpected sidenav icon scale on windows chrome

### DIFF
--- a/packages/devtools/client/components/SideNav.vue
+++ b/packages/devtools/client/components/SideNav.vue
@@ -5,7 +5,7 @@ const tabs = useTabs()
 
 <template>
   <div border="r base" flex="~ col gap-0.5" h-full items-center bg-base z-100>
-    <div flex="~ col" items-center bg-base top-0 pt3 sticky z-1 mb1>
+    <div flex="~ col" items-center bg-base top-0 pt3 sticky z-1 mb1 overflow-overlay>
       <VDropdown placement="left-start" :distance="20">
         <button
 

--- a/packages/devtools/client/styles/global.css
+++ b/packages/devtools/client/styles/global.css
@@ -92,3 +92,12 @@ textarea {
   border-width: 0 !important;
   border-radius: 5px !important;
 }
+
+*::-webkit-scrollbar{
+  width: 3px;
+  height: 3px;
+}
+
+*::-webkit-scrollbar-thumb{
+  background: #878787;
+}


### PR DESCRIPTION
The sidenav's icon could scale unexpectedly too much if the viewport is too narrow on window chrome.
![image](https://user-images.githubusercontent.com/98264874/226124512-2d757c5a-617b-4912-b52b-88e348417764.png)