### PR TITLE
fix: fixed overflowed text

### DIFF
--- a/packages/devtools/client/components/AssetDetails.vue
+++ b/packages/devtools/client/components/AssetDetails.vue
@@ -119,7 +119,7 @@ const supportsPreview = computed(() => {
           </td>
           <td>
             <div flex="~ gap-1" items-center>
-              <FilepathItem :filepath="asset.filePath" w-full line-break ws-normal text-left />
+              <FilepathItem :filepath="asset.filePath" w-full line-break ws-normal text-left overflow-auto />
               <div flex-auto />
               <NIconButton
                 title="Open in Editor"
@@ -135,7 +135,7 @@ const supportsPreview = computed(() => {
           </td>
           <td>
             <div flex="~ gap-1" items-center>
-              <div font-mono>
+              <div overflow-auto font-mono>
                 {{ asset.publicPath }}
               </div>
               <div flex-auto />


### PR DESCRIPTION
if the file path is long, Filepath & Public Path's buttons get lost 