### PR TITLE
fix: fixed openInEditor file suffix

### DIFF
--- a/packages/devtools/src/server-rpc/general.ts
+++ b/packages/devtools/src/server-rpc/general.ts
@@ -101,14 +101,14 @@ export function setupGeneralRPC({ nuxt, refresh }: NuxtDevtoolsServerContext) {
 
       // search for existing path
       const path = [
-        input,
+        input + suffix,
         `${input}.js`,
         `${input}.mjs`,
         `${input}.ts`,
       ].find(i => existsSync(i))
       if (path) {
         // @ts-expect-error missin types
-        await import('launch-editor').then(r => (r.default || r)(path + suffix))
+        await import('launch-editor').then(r => (r.default || r)(path))
       }
       else {
         console.error('File not found:', input)


### PR DESCRIPTION
when you try to open files that has number in it extention(e.g. mp4) it couldn't found the file.