### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -27,7 +27,7 @@ Unleash Nuxt Developer Experience.
   #title
   Developer Experience
   #description
-  Enhance your DX even further, make developement more fun!
+  Enhance your DX even further, make development more fun!
   ::
 
   ::card{icon=🔍}

--- a/docs/content/3.development/0.contributing.md
+++ b/docs/content/3.development/0.contributing.md
@@ -28,7 +28,7 @@ This repo contains the following packages:
 
 Most of the scripts are forward to the root `package.json`. You can run `pnpm dev` in the root folder to start the development server (Nuxt DevTools on top of it's own client UI).
 
-Or you can `cd packages/devtools` and run `pnpm dev` to start the developement server.
+Or you can `cd packages/devtools` and run `pnpm dev` to start the development server.
 
 ### UI Kit
 

--- a/docs/content/3.development/_dir.yml
+++ b/docs/content/3.development/_dir.yml
@@ -1,3 +1,3 @@
 icon: ri:code-box-line
-title: Developement
-navigation.redirect: /developement/contributing
+title: Development
+navigation.redirect: /development/contributing

--- a/local.ts
+++ b/local.ts
@@ -1,5 +1,5 @@
 /**
- * Local developement module entry
+ * Local development module entry
  *
  * Change `@nuxt/devtools` to the absolute path of this module in any of your Nuxt projects,
  * allows you to try Nuxt Devtools locally directly from the source code. HMR is supported


### PR DESCRIPTION
Fix `developement` into `development`.