### PR TITLE
fix(wizard): builtin `enable` setup fails on new installs

### DIFF
--- a/packages/devtools-wizard/src/global.ts
+++ b/packages/devtools-wizard/src/global.ts
@@ -72,12 +72,12 @@ export async function disable(cwd: string, args: string[]) {
 }
 
 function markDisable(rc: RC, path: string) {
-  if (rc.devtoolsGlobal?.projects?.includes(path)) {
+  if (rc?.devtoolsGlobal?.projects?.includes(path)) {
     rc.devtoolsGlobal.projects = rc.devtoolsGlobal.projects.filter((p: string) => p !== path)
     return true
   }
   // remove module if no projects
-  if (!rc.devtoolsGlobal.projects?.length)
+  if (!rc?.devtoolsGlobal?.projects?.length)
     removeModule(rc)
   return false
 }


### PR DESCRIPTION
Running `nuxi devtools enable` on a new install with `nuxt@^3.4.0` makes uses of global `markDisable` function, which tries to read `devtoolsGlobal.projects` from `~/.nuxtrc`. This fails when the `devtoolsGlobal` object does not exist, yielding
`cannot read property of undefined (reading 'projects')` error.

This commit updates the `markDisable` function to safely access RC file properties.