### PR TITLE
fix: nitro storage link

### DIFF
--- a/packages/devtools/client/pages/modules/storage.vue
+++ b/packages/devtools/client/pages/modules/storage.vue
@@ -193,7 +193,7 @@ async function renameCurrentItem() {
       </div>
       <NPanelGrids v-else>
         <NCard px6 py4>
-          Select one key to start.<br>Learn more about <NLink href="https://nitro.unjs.io/guide/introduction/storage" n="orange" target="_blank">
+          Select one key to start.<br>Learn more about <NLink href="https://nitro.unjs.io/guide/storage" n="orange" target="_blank">
             Nitro storage
           </NLink>
         </NCard>


### PR DESCRIPTION
fix nitro storage link
https://nitro.unjs.io/guide/introduction/storage => https://nitro.unjs.io/guide/storage