### PR TITLE
fix(open-graph): use `description` for facebook

### DIFF
--- a/packages/devtools/client/components/social/SocialPreviewGroup.vue
+++ b/packages/devtools/client/components/social/SocialPreviewGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { NormalizedHeadTag, SocialPreviewResolved } from '../../../src/types'
+import type { NormalizedHeadTag } from '../../../src/types'
 
 const props = defineProps<{
   tags: NormalizedHeadTag[]
@@ -13,16 +13,13 @@ const types = [
 
 const selected = ref(types[0])
 
-const card = computed((): SocialPreviewResolved => {
-  return {
-    url: window.location.host,
-    title: props.tags.find(tag => tag.tag === 'title')?.value,
-    image: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'og:image')?.value,
-    imageAlt: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'og:image:alt')?.value,
-    description: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'og:description')?.value,
-    favicon: props.tags.find(tag => tag.tag === 'link' && tag.name === 'icon')?.value,
-  }
-})
+const card = computed(() => getSocialPreviewCard(props.tags, {
+  title: [{ tag: 'title' }],
+  image: [{ tag: 'meta', name: 'og:image' }],
+  imageAlt: [{ tag: 'meta', name: 'og:image:alt' }],
+  description: [{ tag: 'meta', name: 'og:description' }, { tag: 'meta', name: 'description' }],
+  favicon: [{ tag: 'link', name: 'icon' }],
+}))
 </script>
 
 <template>

--- a/packages/devtools/client/components/social/SocialTwitter.vue
+++ b/packages/devtools/client/components/social/SocialTwitter.vue
@@ -1,20 +1,17 @@
 <script setup lang="ts">
-import type { NormalizedHeadTag, SocialPreviewResolved } from '~/../src/types'
+import type { NormalizedHeadTag } from '~/../src/types'
 
 const props = defineProps<{
   tags: NormalizedHeadTag[]
 }>()
 
-const card = computed((): SocialPreviewResolved => {
-  return {
-    url: window.location.host,
-    title: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'twitter:title')?.value || props.tags.find(tag => tag.tag === 'title')?.value,
-    image: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'twitter:image')?.value,
-    imageAlt: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'twitter:image:alt')?.value,
-    description: props.tags.find(tag => tag.tag === 'meta' && tag.name === 'twitter:description')?.value || props.tags.find(tag => tag.tag === 'meta' && tag.name === 'description')?.value,
-    favicon: props.tags.find(tag => tag.tag === 'link' && tag.name === 'icon')?.value,
-  }
-})
+const card = computed(() => getSocialPreviewCard(props.tags, {
+  title: [{ tag: 'title' }],
+  image: [{ tag: 'meta', name: 'twitter:image' }, { tag: 'meta', name: 'og:image' }],
+  imageAlt: [{ tag: 'meta', name: 'twitter:image:alt' }],
+  description: [{ tag: 'meta', name: 'twitter:description' }, { tag: 'meta', name: 'description' }],
+  favicon: [{ tag: 'link', name: 'icon' }],
+}))
 
 const type = computed(() => {
   if (!card.value.image)

--- a/packages/devtools/client/composables/utils.ts
+++ b/packages/devtools/client/composables/utils.ts
@@ -1,6 +1,7 @@
 import { relative } from 'pathe'
 import type { Ref } from 'vue'
 import type { AsyncDataOptions } from '#app'
+import type { NormalizedHeadTag, SocialPreviewCard, SocialPreviewResolved } from '~/../src/types'
 
 export function isNodeModulePath(path: string) {
   return !!path.match(/[/\\]node_modules[/\\]/) || isPackageName(path)
@@ -96,4 +97,26 @@ const requestMethodClass: Record<string, string> = {
 
 export function getRequestMethodClass(method: string) {
   return requestMethodClass[method.toLowerCase()] || requestMethodClass.default
+}
+
+export function getSocialPreviewCard(
+  rawTags: NormalizedHeadTag[],
+  tags: SocialPreviewCard,
+): SocialPreviewResolved {
+  const resolvedTags: { [key: string]: string | undefined } = {}
+
+  for (const [key, value] of Object.entries(tags)) {
+    for (const tag of value) {
+      const tagValue = rawTags.find(item => item.tag === tag.tag && (tag.name ? item.name === tag.name : true))?.value
+      if (tagValue) {
+        resolvedTags[key] = tagValue
+        break
+      }
+    }
+  }
+
+  return {
+    url: window.location.host,
+    ...resolvedTags,
+  }
 }

--- a/packages/devtools/src/types/ui-state.ts
+++ b/packages/devtools/src/types/ui-state.ts
@@ -18,6 +18,20 @@ export interface SocialPreviewResolved {
   imageAlt?: string
 }
 
+export interface SocialPreviewCard {
+  url?: SocialPreviewCardItem[]
+  title?: SocialPreviewCardItem[]
+  description?: SocialPreviewCardItem[]
+  favicon?: SocialPreviewCardItem[]
+  image?: SocialPreviewCardItem[]
+  imageAlt?: SocialPreviewCardItem[]
+}
+
+interface SocialPreviewCardItem {
+  tag: string
+  name?: string
+}
+
 export interface NormalizedHeadTag {
   tag: string
   name: string


### PR DESCRIPTION
facebook use `description` and twitter uses `og:image` tags when there's no `og:` or `twitter:`

<details>
  <summary>Html Head</summary>
  
![image](https://github.com/nuxt/devtools/assets/38922203/666053dc-8b33-4ae3-bafb-94c824f55733)
  </details>

<details>
  <summary>Twitter</summary>
  
![image](https://github.com/nuxt/devtools/assets/38922203/124fb664-a6a0-48fd-a9a2-b4ee2f0db79d)
  </details>

<details>
  <summary>Facebook</summary>
  
  ![image](https://github.com/nuxt/devtools/assets/38922203/0f2d6f8f-1e84-46e1-94dd-5b598370a0eb)
  </details>


thanks to @Atinux