### PR TITLE
fix(ui-kit): set text prop as optional in NSectionBlock

### DIFF
--- a/packages/devtools-ui-kit/src/components/NSectionBlock.vue
+++ b/packages/devtools-ui-kit/src/components/NSectionBlock.vue
@@ -4,7 +4,7 @@ import { useVModel } from '@vueuse/core'
 const props = withDefaults(
   defineProps<{
     icon?: string
-    text: string
+    text?: string
     description?: string
     containerClass?: string
     headerClass?: string


### PR DESCRIPTION
Hi :wave: 
this PR  set the `text` prop as optional for `NSectionBlock` as we can also use `#text` slot.

![image](https://github.com/nuxt/devtools/assets/63512348/e332ade3-91d7-47c2-9186-b96cfed07f87)
