### PR TITLE
fix: devtools close on outside click

### DIFF
--- a/packages/devtools/client/composables/storage.ts
+++ b/packages/devtools/client/composables/storage.ts
@@ -3,7 +3,7 @@ import type { DevToolsFrameState, NuxtDevToolsUIOptions } from '~~/../src/types'
 
 export const isFirstVisit = useLocalStorage('nuxt-devtools-first-visit', true)
 
-const devToolsFrameState = useLocalStorage<DevToolsFrameState>('nuxt-devtools-frame-state', {} as any, { listenToStorageChanges: false })
+const devToolsFrameState = useLocalStorage<DevToolsFrameState>('nuxt-devtools-frame-state', {} as any, { listenToStorageChanges: true })
 
 const devToolsPanelsState = useLocalStorage<Record<string, number>>('nuxt-devtools-panels-state', {} as any, { listenToStorageChanges: false })
 
@@ -15,8 +15,9 @@ watch(devToolsOptions, async (options) => {
 }, { deep: true, flush: 'post' })
 
 // sync devtools options with frame state
-watchEffect(() => {
-  devToolsFrameState.value.closeOnOutsideClick = devToolsOptions.value.interactionCloseOnOutsideClick
+watch(() => devToolsOptions.value.interactionCloseOnOutsideClick, (state) => {
+  if (state !== devToolsFrameState.value.closeOnOutsideClick)
+    devToolsFrameState.value.closeOnOutsideClick = state
 })
 
 // Migrate settings from localStorage to devtools options. TODO: remove in next major release

--- a/packages/devtools/src/runtime/plugins/view/utils.ts
+++ b/packages/devtools/src/runtime/plugins/view/utils.ts
@@ -19,7 +19,7 @@ export function useObjectStorage<T>(key: string, initial: T, readonly = false): 
         return
       wrote = JSON.stringify(value)
       localStorage.setItem(key, wrote)
-    }, { deep: true, flush: 'sync' })
+    }, { deep: true, flush: 'post' })
   }
 
   useEventListener(window, 'storage', (e: StorageEvent) => {


### PR DESCRIPTION
click outside is not working once you have close the window and reopen it, and if we move the panel state position and click on close outside option, it would reset it,
thanks to #273

https://github.com/nuxt/devtools/assets/38922203/a797f39c-ab44-4a38-96be-54371893518c

