### PR TITLE
fix(ComponentGraph): show global components in different color

### DIFF
--- a/packages/devtools-kit/src/_types/options.ts
+++ b/packages/devtools-kit/src/_types/options.ts
@@ -102,6 +102,7 @@ export interface VSCodeTunnelOptions {
 export interface NuxtDevToolsUIOptions {
   componentsView: 'list' | 'graph'
   componentsGraphShowNodeModules: boolean
+  componentsGraphShowGlobalComponents: boolean
   componentsGraphShowPages: boolean
   componentsGraphShowLayouts: boolean
   componentsGraphShowWorkspace: boolean

--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -25,11 +25,9 @@ const config = useServerConfig()
 const layouts = useLayouts()
 const relationships = useComponentsRelationships()
 
-// TODO: waiting for https://github.com/nuxt/devtools/pull/256 so it can be moved to component tab option
-const showGlobalComponents = ref(true)
-
 const {
   componentsGraphShowNodeModules: showNodeModules,
+  componentsGraphShowGlobalComponents: showGlobalComponents,
   componentsGraphShowPages: showPages,
   componentsGraphShowLayouts: showLayouts,
   componentsGraphShowWorkspace: showWorkspace,

--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -66,7 +66,9 @@ const data = computed<Data>(() => {
     const group = rel.id.includes('/node_modules/')
       ? 'lib'
       : component
-        ? 'user'
+        ? component.global
+          ? 'global'
+          : 'user'
         : layout
           ? 'layout'
           : page

--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -25,6 +25,9 @@ const config = useServerConfig()
 const layouts = useLayouts()
 const relationships = useComponentsRelationships()
 
+// TODO: waiting for https://github.com/nuxt/devtools/pull/256 so it can be moved to component tab option
+const showGlobalComponents = ref(true)
+
 const {
   componentsGraphShowNodeModules: showNodeModules,
   componentsGraphShowPages: showPages,
@@ -63,7 +66,9 @@ const data = computed<Data>(() => {
     const group = rel.id.includes('/node_modules/')
       ? 'lib'
       : component
-        ? 'user'
+        ? component.global
+          ? 'global'
+          : 'user'
         : layout
           ? 'layout'
           : page
@@ -77,6 +82,8 @@ const data = computed<Data>(() => {
     if (!showLayouts.value && group === 'layout')
       return null
     if (!showWorkspace.value && group === 'user' && config.value && !rel.id.startsWith(config.value.rootDir))
+      return null
+    if (!showGlobalComponents.value && group === 'global')
       return null
 
     const shape = group === 'layout'
@@ -184,6 +191,7 @@ function setFilter() {
 <template>
   <Navbar ref="navbar" absolute left-0 right-0 top-0>
     <template #search>
+      <TestGC />
       <NCheckbox v-model="showPages" n="primary sm">
         <span op75>Show pages</span>
       </NCheckbox>
@@ -196,6 +204,9 @@ function setFilter() {
       <NCheckbox v-model="showNodeModules" n="primary sm">
         <span op75>Show node_modules</span>
       </NCheckbox>
+      <NCheckbox v-model="showGlobalComponents" n="primary sm">
+        <span op75>Show global components</span>
+      </NCheckbox>
       <button v-if="selectedFilter" flex="~ gap-1" items-center rounded-full bg-gray:20 py1 pl3 pr2 text-xs op50 hover:op100 @click="selectedFilter = undefined">
         Clear filter <div i-carbon-close />
       </button>
@@ -204,6 +215,8 @@ function setFilter() {
     </template>
   </Navbar>
 
+  <!-- {{ data }} -->
+
   <div relative h-full w-full>
     <div ref="container" h-full w-full />
     <NCard absolute bottom-3 left-3 border-0 p2 px3 text-sm glass-effect>
@@ -211,6 +224,10 @@ function setFilter() {
         <div h-3 w-3 rounded-full bg-hex-42b883 />
         <div op50>
           Component
+        </div>
+        <div h-3 w-3 rounded-full bg-hex-97c2fc />
+        <div op50>
+          Global Component
         </div>
         <div h-3 w-3 bg-hex-42b2b8 />
         <div op50>

--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -66,9 +66,7 @@ const data = computed<Data>(() => {
     const group = rel.id.includes('/node_modules/')
       ? 'lib'
       : component
-        ? component.global
-          ? 'global'
-          : 'user'
+        ? 'user'
         : layout
           ? 'layout'
           : page
@@ -191,7 +189,6 @@ function setFilter() {
 <template>
   <Navbar ref="navbar" absolute left-0 right-0 top-0>
     <template #search>
-      <TestGC />
       <NCheckbox v-model="showPages" n="primary sm">
         <span op75>Show pages</span>
       </NCheckbox>
@@ -214,8 +211,6 @@ function setFilter() {
       <slot />
     </template>
   </Navbar>
-
-  <!-- {{ data }} -->
 
   <div relative h-full w-full>
     <div ref="container" h-full w-full />

--- a/packages/devtools/src/server-rpc/ui-options.ts
+++ b/packages/devtools/src/server-rpc/ui-options.ts
@@ -8,6 +8,7 @@ import type { NuxtDevToolsUIOptions, NuxtDevtoolsServerContext, ServerFunctions 
 const defaults: NuxtDevToolsUIOptions = {
   componentsView: 'list',
   componentsGraphShowNodeModules: false,
+  componentsGraphShowGlobalComponents: true,
   componentsGraphShowPages: false,
   componentsGraphShowLayouts: false,
   componentsGraphShowWorkspace: true,


### PR DESCRIPTION
close #188 

<details>
  <summary>before</summary>
  
  ![image](https://github.com/nuxt/devtools/assets/38922203/09826d0c-799e-4265-ba9c-f50612ed0f89)

</details>


<details>
  <summary>after</summary>

both component are global
  
![image](https://github.com/nuxt/devtools/assets/38922203/667d1893-8879-4b66-8517-aad84b4f317b)

</details>