### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,28 @@
+name: 🐛 Bug report
+description: Something's not working
+title: 'fix: '
+labels: [bug]
+body:
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: 🐛 The bug
+      description: What isn't working? Describe what the bug is.
+  - type: input
+    validations:
+      required: true
+    attributes:
+      label: 🛠️ To reproduce
+      description: A reproduction of the bug
+      placeholder: https://stackblitz.com/[...]
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: 🌈 Expected behavior
+      description: What did you expect to happen? Is there a section in the docs about this?
+  - type: textarea
+    attributes:
+      label: ℹ️ Additional context
+      description: Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,20 @@
+name: 📚 Documentation
+description: How do I ... ?
+title: 'docs: '
+labels: [documentation]
+body:
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: 📚 Is your documentation request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: I feel I should be able to [...] but I can't see how to do it from the docs.
+  - type: textarea
+    attributes:
+      label: 🔍 Where should you find it?
+      description: What page of the docs do you expect this information to be found on?
+  - type: textarea
+    attributes:
+      label: ℹ️ Additional context
+      description: Add any other context or information.

--- a/.github/ISSUE_TEMPLATE/feature-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/feature-suggestion.yml
@@ -1,0 +1,26 @@
+name: 🆕 Feature suggestion
+description: Suggest an idea
+title: 'feat: '
+labels: [enhancement]
+body:
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: 🆒 Your use case
+      description: Add a description of your use case, and how this feature would help you.
+      placeholder: When I do [...] I would expect to be able to do [...]
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: 🆕 The solution you'd like
+      description: Describe what you want to happen.
+  - type: textarea
+    attributes:
+      label: 🔍 Alternatives you've considered
+      description: Have you considered any alternative solutions or features?
+  - type: textarea
+    attributes:
+      label: ℹ️ Additional info
+      description: Is there any other context you think would be helpful to know?

--- a/.github/ISSUE_TEMPLATE/help-wanted.yml
+++ b/.github/ISSUE_TEMPLATE/help-wanted.yml
@@ -1,0 +1,20 @@
+name: 🆘 Help
+description: I need help with ...
+title: 'help: '
+labels: [help wanted]
+body:
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: 📚 What are you trying to do?
+      description: A clear and concise description of your objective.
+      placeholder: I'm not sure how to [...].
+  - type: textarea
+    attributes:
+      label: 🔍 What have you tried?
+      description: Have you looked through the docs? Tried different approaches? The more detail the better.
+  - type: textarea
+    attributes:
+      label: ℹ️ Additional context
+      description: Add any other context or information.


### PR DESCRIPTION
copy the templates from [ionic module](https://github.com/nuxt-modules/ionic/tree/main/.github/ISSUE_TEMPLATE), thanks to daniel for this
I remove `assignees` as I didn't know who to add