### PR TITLE
fix: respect Nuxt's `devServer` config when creating request for auth URL

### DIFF
--- a/packages/devtools/src/server-rpc/general.ts
+++ b/packages/devtools/src/server-rpc/general.ts
@@ -158,7 +158,7 @@ export function setupGeneralRPC({ nuxt, options, refresh, openInEditorHooks }: N
         c.bold(info),
         '',
         'Please open the following URL in the browser:',
-        c.bold(c.green(`http://localhost:${nuxt.options.devServer.port}${ROUTE_AUTH}?token=${token}`)),
+        c.bold(c.green(`${nuxt.options.devServer.https ? 'https' : 'http'}://${nuxt.options.devServer.host || 'localhost'}:${nuxt.options.devServer.port}${ROUTE_AUTH}?token=${token}`)),
         '',
         'Or manually copy and paste the following token:',
         c.bold(c.cyan(token)),


### PR DESCRIPTION
Resolves #326 (+ takes into account a possibility of different host)