### PR TITLE
fix(server-routes): filter only dir as collection

### DIFF
--- a/packages/devtools/client/pages/modules/server-routes.vue
+++ b/packages/devtools/client/pages/modules/server-routes.vue
@@ -59,9 +59,6 @@ const filterByCollection = computed(() => {
     const collectionNames = filepathParts.slice(filepathParts.indexOf('server') + 1)
 
     if (collectionNames.length > 0 && collectionNames[collectionNames.length - 1].includes('.'))
-      collectionNames[collectionNames.length - 1] = collectionNames[collectionNames.length - 1].split('.')[0]
-
-    if (collectionNames.length > 0 && collectionNames[collectionNames.length - 1] === 'index')
       collectionNames.pop()
 
     let parentCollection: ServerRouteInfo | null = null


### PR DESCRIPTION
the current filtering would be like: (if there is multiple files with same name e.g. [id], it would add it to one collection and I think this would make things complicated)
![image](https://github.com/nuxt/devtools/assets/38922203/250ff066-946b-4801-851b-ddf9391fbf02)


so in this update, only the dirs will be as collection:
![image](https://github.com/nuxt/devtools/assets/38922203/537280cc-c473-49d0-a91f-73d294fc37c7)
