### PR TITLE
feat: install modules at once

### DIFF
--- a/packages/devtools/src/server-rpc/npm.ts
+++ b/packages/devtools/src/server-rpc/npm.ts
@@ -106,7 +106,7 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
 
         await Promise.resolve()
 
-        // remove module from install queue
+        // remove module from install set
         installSet.delete(name)
 
         const code = result.exitCode

--- a/packages/devtools/src/server-rpc/npm.ts
+++ b/packages/devtools/src/server-rpc/npm.ts
@@ -78,7 +78,7 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
 
       // use the latest generated config if available
       let source = latestGenerated
-      if (source === null)
+      if (source == null)
         source = await fs.readFile(filepath, 'utf-8')
       const mod = parseModule(source, { sourceFileName: filepath })
 
@@ -116,8 +116,10 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
         }
 
         // If all modules have been installed, write back to the config file, and auto restart.
-        if (installSet.size === 0)
+        if (installSet.size === 0) {
+          latestGenerated = null
           await fs.writeFile(filepath, generated, 'utf-8')
+        }
       }
 
       return {

--- a/packages/devtools/src/server-rpc/npm.ts
+++ b/packages/devtools/src/server-rpc/npm.ts
@@ -54,6 +54,9 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
     }
   }
 
+  const installQueue: string[] = []
+  let latestGenerated: string | null = null
+
   return {
     checkForUpdateFor(name: string) {
       if (!updatesPromise.has(name))
@@ -72,16 +75,23 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
       const commands = (await getNpmCommand('install', name, { dev: true }))!
 
       const filepath = nuxt.options._nuxtConfigFile
-      const source = await fs.readFile(filepath, 'utf-8')
-      const mod = await parseModule(source, { sourceFileName: filepath })
+
+      // use the latest generated config if available
+      let source = latestGenerated
+      if (source === null)
+        source = await fs.readFile(filepath, 'utf-8')
+      const mod = parseModule(source, { sourceFileName: filepath })
 
       addNuxtModule(mod, name)
 
       const generated = mod.generate().code
+      latestGenerated = generated // cache the latest generated config
 
       const processId = `nuxt:add-module:${name}`
 
       if (!dry) {
+        installQueue.push(name)
+
         const process = startSubprocess({
           command: commands[0],
           args: commands.slice(1),
@@ -97,13 +107,18 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
 
         await Promise.resolve()
 
+        // remove module from install queue
+        installQueue.splice(installQueue.indexOf(name), 1)
+
         const code = result.exitCode
         if (code !== 0) {
           console.error(result.stderr)
           throw new Error(`Failed to install module, process exited with ${code}`)
         }
 
-        await fs.writeFile(filepath, generated, 'utf-8')
+        // If all modules have been installed, write back to the config file, and auto restart.
+        if (installQueue.length === 0)
+          await fs.writeFile(filepath, generated, 'utf-8')
       }
 
       return {


### PR DESCRIPTION
Resolve #331 

Implemented an install queue: I added an installQueue where the module name is pushed into the queue when the module starts installing. When the module installation is complete, the module name is removed from the queue.

Only when all modules are installed is the new configuration written to the file. This prevents an automatic reboot when updating the config, which would result in only one module being installed.