### PR TITLE
fix(kit): broken types for `useDevtoolsClient()`

### DIFF
--- a/packages/devtools-kit/src/runtime/iframe-client.ts
+++ b/packages/devtools-kit/src/runtime/iframe-client.ts
@@ -1,6 +1,6 @@
 import type { Ref } from 'vue'
 import { shallowRef, triggerRef } from 'vue'
-import type { NuxtDevtoolsIframeClient } from '../../src/_types/client-api'
+import type { NuxtDevtoolsIframeClient } from '../types'
 
 let clientRef: Ref<NuxtDevtoolsIframeClient | undefined> | undefined
 const hasSetup = false


### PR DESCRIPTION
Currently the type is broken because it's loading the interface from a broken path.

```ts
import type { NuxtDevtoolsIframeClient } from '../../src/_types/client-api';
```

See https://unpkg.com/browse/@nuxt/devtools-kit@0.7.0/dist/runtime/iframe-client.d.ts.

