### PR TITLE
fix(kit): types for `renderCodeHighlight`

### DIFF
--- a/packages/devtools-kit/build.config.ts
+++ b/packages/devtools-kit/build.config.ts
@@ -23,6 +23,7 @@ export default defineBuildConfig({
     'hookable',
     'vite-plugin-vue-inspector',
     'error-stack-parser-es',
+    'shiki-es',
   ],
   declaration: true,
   rollup: {

--- a/packages/devtools-kit/src/_types/client-api.ts
+++ b/packages/devtools-kit/src/_types/client-api.ts
@@ -4,6 +4,7 @@ import type { AppConfig } from 'nuxt/schema'
 import type { NuxtApp } from 'nuxt/dist/app/nuxt'
 import type { Hookable } from 'hookable'
 import type { BirpcReturn } from 'birpc'
+import type { Lang } from 'shiki-es'
 import type { ServerFunctions } from './rpc'
 import type { HookInfo, LoadingTimeMetric, PluginMetric, VueInspectorClient, VueInspectorData } from './integrations'
 import type { TimelineMetrics } from './timeline-metrics'
@@ -83,7 +84,7 @@ export interface NuxtDevtoolsHostClient {
 
 export interface NuxtDevtoolsClient {
   rpc: BirpcReturn<ServerFunctions>
-  renderCodeHighlight: (code: string, lang: string, lines?: boolean, theme?: string) => {
+  renderCodeHighlight: (code: string, lang: Lang) => {
     code: string
     supported: boolean
   }

--- a/packages/devtools-kit/src/_types/client-api.ts
+++ b/packages/devtools-kit/src/_types/client-api.ts
@@ -84,7 +84,7 @@ export interface NuxtDevtoolsHostClient {
 
 export interface NuxtDevtoolsClient {
   rpc: BirpcReturn<ServerFunctions>
-  renderCodeHighlight: (code: string, lang: Lang) => {
+  renderCodeHighlight: (code: string, lang?: Lang) => {
     code: string
     supported: boolean
   }

--- a/packages/devtools-ui-kit/src/components/NCodeBlock.vue
+++ b/packages/devtools-ui-kit/src/components/NCodeBlock.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 // This components requires to run in DevTools to render correctly
 import { computed, nextTick } from 'vue'
+import type { Lang } from 'shiki-es'
 import { devToolsClient } from '../runtime/client'
 
 const props = withDefaults(
   defineProps<{
     code: string
-    lang?: string
+    lang?: Lang
     lines?: boolean
     transformRendered?: (code: string) => string
   }>(), {
@@ -17,7 +18,7 @@ const props = withDefaults(
 const emit = defineEmits(['loaded'])
 
 const rendered = computed(() => {
-  const result = devToolsClient.value?.devtools.renderCodeHighlight(props.code, props.lang as string) || { code: props.code, supported: false }
+  const result = devToolsClient.value?.devtools.renderCodeHighlight(props.code, props.lang) || { code: props.code, supported: false }
   if (result.supported && props.transformRendered)
     result.code = props.transformRendered(result.code)
   if (result.supported)

--- a/packages/devtools/client/composables/client-services/shiki.ts
+++ b/packages/devtools/client/composables/client-services/shiki.ts
@@ -5,7 +5,7 @@ export const shiki = ref<Highlighter>()
 
 let promise: Promise<any> | null = null
 
-export function renderCodeHighlight(code: string, lang: Lang) {
+export function renderCodeHighlight(code: string, lang?: Lang) {
   const mode = useColorMode()
 
   if (!promise && !shiki.value) {

--- a/packages/devtools/client/composables/client.ts
+++ b/packages/devtools/client/composables/client.ts
@@ -1,4 +1,3 @@
-import type { Lang } from 'shiki-es'
 import type { NuxtDevtoolsClient, NuxtDevtoolsHostClient, NuxtDevtoolsIframeClient, VueInspectorData } from '@nuxt/devtools-kit/types'
 import type { Unhead } from '@unhead/schema'
 import { renderMarkdown } from './client-services/markdown'
@@ -47,7 +46,7 @@ export function useInjectionClient(): ComputedRef<NuxtDevtoolsIframeClient> {
       rpc,
       colorMode: mode.value,
       renderCodeHighlight(code, lang) {
-        return renderCodeHighlight(code, lang as Lang)
+        return renderCodeHighlight(code, lang)
       },
       renderMarkdown(code) {
         return renderMarkdown(code)


### PR DESCRIPTION
As far as I could tell, `lines` and `theme` don't do anything.

We also type the supported langs because we can. 