### PR TITLE
fix(ui-kit): dialog closing and a11y

### DIFF
--- a/packages/devtools-ui-kit/src/components/NDialog.vue
+++ b/packages/devtools-ui-kit/src/components/NDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watchEffect } from 'vue'
-import { useVModel } from '@vueuse/core'
+import { onClickOutside, useVModel } from '@vueuse/core'
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap'
 
 const props = withDefaults(

--- a/packages/devtools-ui-kit/src/components/NDialog.vue
+++ b/packages/devtools-ui-kit/src/components/NDialog.vue
@@ -7,10 +7,12 @@ const props = withDefaults(
   defineProps<{
     modelValue?: boolean
     dim?: boolean
+    autoClose?: boolean
   }>(),
   {
     modelValue: false,
     dim: true,
+    autoClose: true,
   },
 )
 
@@ -37,10 +39,14 @@ watchEffect(
   },
 )
 
-function close() {
-  show.value = false
-  emit('close')
-}
+onClickOutside(card, () => {
+  if (props.modelValue && props.autoClose) {
+    show.value = false
+    emit('close')
+  }
+}, {
+  ignore: ['a', 'button', 'summary'],
+})
 </script>
 
 <script lang="ts">
@@ -54,6 +60,8 @@ export default {
     <div
       v-show="show"
       class="n-dialog fixed inset-0 z-100 flex items-center justify-center n-transition"
+      role="dialog"
+      aria-modal="true"
       :class="[
         show ? '' : 'op0 pointer-events-none visibility-none',
       ]"
@@ -61,9 +69,8 @@ export default {
       <div
         class="absolute inset-0 -z-1"
         :class="[
-          dim ? 'bg-black/50' : '',
+          dim ? 'glass-effect' : '',
         ]"
-        @click="close()"
       />
       <NCard v-bind="$attrs" ref="card" class="max-h-screen of-auto">
         <slot />

--- a/packages/devtools/client/components/DrawerRight.vue
+++ b/packages/devtools/client/components/DrawerRight.vue
@@ -17,7 +17,7 @@ onClickOutside(el, () => {
   if (props.modelValue && props.autoClose)
     emit('close')
 }, {
-  ignore: ['a', 'button', 'summary'],
+  ignore: ['a', 'button', 'summary', '[role="dialog"]'],
 })
 </script>
 


### PR DESCRIPTION
Seems like the introduction of the focus trap on NDialog stopped the dialog closing when clicking on the backdrop.

[Peek 2023-07-27 14-46.webm](https://github.com/nuxt/devtools/assets/5326365/902208b9-7580-4f87-91ce-8e95a879af78)

(I'm clicking on the backdrop in the video)

To fix it we implement the same logic that the DrawerRight component uses. We also fix some i18n issues and have better styling for dark mode.
