### PR TITLE
feat: enhance state editor

### DIFF
--- a/packages/devtools/client/components/StateEditor.vue
+++ b/packages/devtools/client/components/StateEditor.vue
@@ -4,7 +4,7 @@ import JsonEditorVue from 'json-editor-vue'
 const props = defineProps<{
   name?: string
   open?: boolean
-  state?: Record<string, any> | string | number | null | undefined
+  state?: any
   readonly?: boolean
 }>()
 
@@ -77,7 +77,6 @@ async function refresh() {
     </div>
     <template v-if="isOpen || !name">
       <JsonEditorVue
-        v-if="state && Object.keys(state).length > 0 || typeof state === 'number' || typeof state === 'string'"
         v-model="proxy"
         v-bind="$attrs"
         class="json-editor-vue"
@@ -92,9 +91,6 @@ async function refresh() {
         :indentation="2"
         :tab-size="2"
       />
-      <div v-else bg-active p5 italic>
-        <span op50>No data</span>
-      </div>
     </template>
   </div>
 </template>

--- a/packages/devtools/client/components/StateEditor.vue
+++ b/packages/devtools/client/components/StateEditor.vue
@@ -4,7 +4,7 @@ import JsonEditorVue from 'json-editor-vue'
 const props = defineProps<{
   name?: string
   open?: boolean
-  state?: Record<string, any>
+  state?: Record<string, any> | string | number | null | undefined
   readonly?: boolean
 }>()
 
@@ -13,14 +13,21 @@ const emit = defineEmits<{
 }>()
 
 const isOpen = useVModel(props, 'open', emit, { passive: true })
-
 const colorMode = useColorMode()
 const proxy = ref()
-proxy.value = JSON.parse(JSON.stringify(props.state))
+
+const state = useState(props.name)
+if (props.state)
+  proxy.value = JSON.parse(JSON.stringify(props.state))
+else if (typeof props.state === 'number' || typeof props.state !== 'string')
+  proxy.value = props.state
 
 const watcher = watchPausable(proxy,
   (value) => {
-    deepSync(value, props.state)
+    if (typeof value !== 'number' && typeof value !== 'string')
+      deepSync(value, props.state)
+    else
+      state.value = value
   },
   { deep: true },
 )
@@ -70,7 +77,7 @@ async function refresh() {
     </div>
     <template v-if="isOpen || !name">
       <JsonEditorVue
-        v-if="state && Object.keys(state).length > 0"
+        v-if="state && Object.keys(state).length > 0 || typeof state === 'number' || typeof state === 'string'"
         v-model="proxy"
         v-bind="$attrs"
         class="json-editor-vue"


### PR DESCRIPTION
**Current Issue**

Currently, StateEditor can only edit json like data.
However, we often store data of type string or number. If the value is an empty string or a number, "No data" is displayed. If you define `useState('test:undefined', () => undefined)`, it even make the whole tab won't display.

In fact, we probably don't need "no data", because even if it's an empty array, object or even `undefined` or `null`, we should still be able to append data or edit it.

---

**What I did**

- In this pr, I make sure that numbers and strings are edited properly and remain reactive.
- Now "no data" will not be displayed so that we can edit empty arrays or objects.

---

**legacy issue**

There are still issues that have not been addressed:

Empty strings and undefined data currently show a strange built-in hint for third-party editors, although they can still be edited normally.

Type of empty strings data become number if a number is entered.

These may be issues with third party editors, perhaps we use simpler editing methods such as input element when editing numbers or strings.

![image](https://github.com/nuxt/devtools/assets/29743310/9cfd7f60-f672-4670-a101-a053d7cc1011)
