### PR TITLE
docs: update 0.index.md

### DIFF
--- a/docs/content/1.guide/0.index.md
+++ b/docs/content/1.guide/0.index.md
@@ -76,4 +76,4 @@ export default defineNuxtConfig({
 })
 ```
 
-For all options available, please refer to TSDocs in your IDE, or the [type definition file](https://github.com/nuxt/devtools/blob/main/packages/devtools/src/types.ts#L14).
+For all options available, please refer to TSDocs in your IDE, or the [type definition file](https://github.com/nuxt/devtools/blob/main/packages/devtools-kit/src/_types/options.ts#L6).


### PR DESCRIPTION
Submitting a simple change to a link.

- Updates the link in the documentation for the types file to go directly to the file that contains the module options types.