### PR TITLE
fix: add AuthRequiredPanel to AuthConfirmDialog

### DIFF
--- a/packages/devtools/client/components/AuthConfirmDialog.vue
+++ b/packages/devtools/client/components/AuthConfirmDialog.vue
@@ -5,7 +5,13 @@ import { AuthConfirm } from '~/composables/dialog'
 <template>
   <AuthConfirm v-slot="{ resolve }">
     <NDialog :model-value="!isDevAuthed" class="border-none" @close="resolve(false)">
-      <AuthRequiredPanel />
+      <AuthRequiredPanel>
+        <template #actions>
+          <NButton @click="resolve(false)">
+            Cancel
+          </NButton>
+        </template>
+      </AuthRequiredPanel>
     </NDialog>
   </AuthConfirm>
 </template>

--- a/packages/devtools/client/components/AuthConfirmDialog.vue
+++ b/packages/devtools/client/components/AuthConfirmDialog.vue
@@ -1,30 +1,11 @@
 <script setup lang="ts">
-import { AuthComfirm } from '~/composables/dialog'
+import { AuthConfirm } from '~/composables/dialog'
 </script>
 
 <template>
-  <AuthComfirm v-slot="{ resolve }">
-    <NDialog :model-value="true" @close="resolve(false)">
-      <div p4 flex="~ col gap-2">
-        <h3 class="mb2 text-lg font-medium leading-6" flex="~ items-center gap-1" text-orange>
-          <span class="i-carbon-information-square" /> Permissions required
-        </h3>
-        <p>
-          This operation requires permissions for running command and access files from the browser.
-        </p>
-        <p>
-          A request is sent to the server.<br>
-          Please check your terminal for the instructions and then come back.
-        </p>
-        <div flex="~ gap-3" mt2 justify-end>
-          <NButton @click="resolve(false)">
-            Cancel
-          </NButton>
-          <NButton disabled icon="i-carbon-time">
-            Waiting for authorization...
-          </NButton>
-        </div>
-      </div>
+  <AuthConfirm v-slot="{ resolve }">
+    <NDialog :model-value="!isDevAuthed" class="border-none" @close="resolve(false)">
+      <AuthRequiredPanel />
     </NDialog>
-  </AuthComfirm>
+  </AuthConfirm>
 </template>

--- a/packages/devtools/client/components/AuthRequiredPanel.vue
+++ b/packages/devtools/client/components/AuthRequiredPanel.vue
@@ -32,7 +32,7 @@ async function input() {
 
 <template>
   <NPanelGrids v-if="!isDevAuthed">
-    <NCard flex="~ col gap-2" mxa items-center p6 text-center>
+    <NCard flex="~ col gap-2" mxa p6>
       <h3 class="mb2 text-lg font-medium leading-6" flex="~ items-center gap-1" text-orange>
         <span class="i-carbon-information-square" /> Permissions required
       </h3>
@@ -43,20 +43,22 @@ async function input() {
         A request is sent to the server.<br>
         Please check your terminal for the instructions and then come back.
       </p>
-      <div flex="~ gap-3" mt2 justify-end>
+      <div flex="~ gap-3" mt5 justify-between>
+        <form relative flex="~ inline gap-2 items-center" @submit.prevent="input">
+          <p absolute left-1 top--5 text-xs op-50>
+            Or you can manually paste the token below:
+          </p>
+          <NTextInput
+            v-model="authInput" placeholder="Enter token here"
+            :n="isFailed ? 'red' : undefined"
+            @keydown.enter="input"
+          />
+          <NIconButton border="~ base" hover="border-primary text-green" p3.8 icon="i-carbon-arrow-right" @click="input" />
+        </form>
         <NButton disabled icon="i-carbon-time">
           Waiting for authorization...
         </NButton>
       </div>
-      <p>Or you can manually paste the token here:</p>
-      <form flex="~ inline gap-2 items-center" @submit.prevent="input">
-        <NTextInput
-          v-model="authInput" placeholder="Enter token here"
-          :n="isFailed ? 'red' : undefined"
-          @keydown.enter="input"
-        />
-        <NIconButton icon="i-carbon-arrow-right" @click="input" />
-      </form>
     </NCard>
   </NPanelGrids>
   <template v-else>

--- a/packages/devtools/client/components/AuthRequiredPanel.vue
+++ b/packages/devtools/client/components/AuthRequiredPanel.vue
@@ -55,9 +55,12 @@ async function input() {
           />
           <NIconButton border="~ base" hover="border-primary text-green" p3.8 icon="i-carbon-arrow-right" @click="input" />
         </form>
-        <NButton disabled icon="i-carbon-time">
-          Waiting for authorization...
-        </NButton>
+        <div flex="~ gap-2">
+          <slot name="actions" />
+          <NButton disabled icon="i-carbon-time">
+            Waiting for authorization...
+          </NButton>
+        </div>
       </div>
     </NCard>
   </NPanelGrids>

--- a/packages/devtools/client/composables/dialog.ts
+++ b/packages/devtools/client/composables/dialog.ts
@@ -2,7 +2,7 @@ import type { InstallModuleReturn, ModuleActionType, ModuleStaticInfo } from '..
 
 export const ModuleDialog = createTemplatePromise<boolean, [info: ModuleStaticInfo, result: InstallModuleReturn, type: ModuleActionType]>()
 
-export const AuthComfirm = createTemplatePromise<boolean>()
+export const AuthConfirm = createTemplatePromise<boolean>()
 
 interface RestartDialog {
   id: string


### PR DESCRIPTION
the `AuthConfirmDialog` UI is diffrent than `AuthRequiredPanel`(for example it doen't have an input for manuel token), not sure if it was on purpose

old UI:
![image](https://github.com/nuxt/devtools/assets/38922203/5aae45d8-4457-45c5-b51d-2a378c0da4bb)


the current UI looks like:
![Untitled](https://github.com/nuxt/devtools/assets/38922203/63337c2b-6b4a-442f-a169-b382dc011f91)
