### PR TITLE
fix: notification z-index

### DIFF
--- a/packages/devtools/client/components/Notification.vue
+++ b/packages/devtools/client/components/Notification.vue
@@ -17,7 +17,7 @@ provideNotificationFn((data) => {
 
 <template>
   <div
-    fixed left-0 right-0 top-0 z-50 text-center
+    fixed left-0 right-0 top-0 z-999 text-center
     :class="show ? '' : 'pointer-events-none overflow-hidden'"
   >
     <div


### PR DESCRIPTION
The `Dialog` z-index is higher than `Notification` component and sometimes it make the notification disappear