### PR TITLE
fix(server-routes): filter middleware from scannedHandlers

### DIFF
--- a/packages/devtools/src/server-rpc/server-routes.ts
+++ b/packages/devtools/src/server-rpc/server-routes.ts
@@ -33,7 +33,9 @@ export function setupServerRoutesRPC({ nuxt, refresh }: NuxtDevtoolsServerContex
       if (!nitro)
         return []
       return [
-        ...nitro.scannedHandlers.map(item => ({
+        ...nitro.scannedHandlers
+        .filter(item => !item.middleware)
+        .map(item => ({
           route: item.route,
           filepath: item.handler,
           method: item.method,


### PR DESCRIPTION
probably this would close #332

the storage file from a reproduction looked like this:
![image](https://github.com/nuxt/devtools/assets/38922203/f49184f9-f8c1-42d5-a575-9282df4b4ac4)

this is caused by selecting a middleware (which was added to routes list) and becuase middleware has only `handler` and `middleware` property, it broke it.