### PR TITLE
chore(deps): update fast-folder-size to 2.2.0

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -47,7 +47,7 @@
     "consola": "^3.2.3",
     "error-stack-parser-es": "^0.1.0",
     "execa": "^7.2.0",
-    "fast-folder-size": "^2.1.0",
+    "fast-folder-size": "^2.2.0",
     "fast-glob": "^3.3.1",
     "get-port-please": "^3.0.1",
     "global-dirs": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       fast-folder-size:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^2.2.0
+        version: 2.2.0
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
@@ -2158,6 +2158,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -2166,6 +2167,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -2174,6 +2176,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -2182,6 +2185,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     optional: true
 
@@ -2190,6 +2194,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     optional: true
 
@@ -5844,8 +5849,8 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  /fast-folder-size@2.1.0:
-    resolution: {integrity: sha512-3h+e4YJJ6fze5RMaByScrfRdHE+DnM/as8r/jbjmIGhgty6v2yBRNbtOiItqhRitv4kBv8WAOQvbPtnyYK3gHw==}
+  /fast-folder-size@2.2.0:
+    resolution: {integrity: sha512-7VsTlT/ELl5OQ4fnckM3idvaUkdJxf6VaYn0sC43GWoRmKqvbGfpoyC4BC/imTd9CEZtlfNsEf8/ZqdfoU4Nwg==}
     hasBin: true
     requiresBuild: true
     dependencies:


### PR DESCRIPTION
This enables users to reuse an existing du.zip locally.

I was attempt to logging something in the console when downloading the du.zip, but it dosen't appears, then I found this issue: https://github.com/npm/cli/issues/3347 , I think there should be some other way to notify users when hitting du.zip download issue.

See https://github.com/simoneb/fast-folder-size/releases/tag/v2.2.0