### PR TITLE
fix(settings): make sure client has value

### DIFF
--- a/packages/devtools/client/pages/settings.vue
+++ b/packages/devtools/client/pages/settings.vue
@@ -73,11 +73,13 @@ function pinMove(name: string, delta: number) {
 
 // sync devtools options with frame state
 watchEffect(() => {
-  client.value.app.frameState.value.closeOnOutsideClick = interactionCloseOnOutsideClick.value
+  if (client.value)
+    client.value.app.frameState.value.closeOnOutsideClick = interactionCloseOnOutsideClick.value
 })
 
 watchEffect(() => {
-  client.value.app.frameState.value.minimizePanelInactive = minimizePanelInactive.value
+  if (client.value)
+    client.value.app.frameState.value.minimizePanelInactive = minimizePanelInactive.value
 })
 </script>
 


### PR DESCRIPTION
make sure client has value to prevent from getting error `"Cannot read properties of undefined (reading 'app')"`