### PR TITLE
feat: hide panel by default when not explicit enabled

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -22,14 +22,15 @@ const { data } = await useAsyncData('landing', () => {
     queryContent('/').findOne(),
   ])
 })
-const [getStarted, page] = data.value
+
+const [getStarted, page] = data.value! || []
 
 const intervalId = ref()
 const currentStep = ref(0)
 const projectsSectionVisible = ref(false)
 const nuxtProjectsSection = ref(null)
 
-const { data: module } = await useFetch<{
+const { data: mod } = await useFetch<{
   stats: {
     downloads: number
     stars: number
@@ -216,9 +217,9 @@ watch(projectsSectionVisible, () => {
         </template>
 
         <template #links>
-          <UAvatarGroup :max="13" size="md" class="flex-wrap lg:self-start [&_span:first-child]:text-xs">
+          <UAvatarGroup v-if="mod" :max="13" size="md" class="flex-wrap lg:self-start [&_span:first-child]:text-xs">
             <UTooltip
-              v-for="(contributor, idx) of module.contributors" :key="idx" :text="contributor.username"
+              v-for="(contributor, idx) of mod.contributors" :key="idx" :text="contributor.username"
               class="rounded-full" :ui="{ background: 'bg-gray-50 dark:bg-gray-800/50' }"
               :popper="{ offsetDistance: 16 }"
             >
@@ -241,12 +242,12 @@ watch(projectsSectionVisible, () => {
           </p>
         </template>
 
-        <div class="flex flex-col items-center justify-center gap-8 sm:flex-row lg:gap-16">
+        <div v-if="mod" class="flex flex-col items-center justify-center gap-8 sm:flex-row lg:gap-16">
           <NuxtLink class="group text-center" to="https://npmjs.org/package/@nuxt/devtools" target="_blank">
             <p
               class="group-hover:text-primary-500 dark:group-hover:text-primary-400 text-6xl font-semibold text-gray-900 dark:text-white"
             >
-              {{ formatNumber(module.stats.downloads) }}+
+              {{ formatNumber(mod.stats.downloads) }}+
             </p>
             <p>Monthly Downloads</p>
           </NuxtLink>
@@ -255,7 +256,7 @@ watch(projectsSectionVisible, () => {
             <p
               class="group-hover:text-primary-500 dark:group-hover:text-primary-400 text-6xl font-semibold text-gray-900 dark:text-white"
             >
-              {{ formatNumber(module.stats.stars) }}+
+              {{ formatNumber(mod.stats.stars) }}+
             </p>
             <p>Stars</p>
           </NuxtLink>

--- a/packages/devtools-kit/src/_types/options.ts
+++ b/packages/devtools-kit/src/_types/options.ts
@@ -163,6 +163,7 @@ export interface NuxtDevToolsOptions {
     scale: number
     showExperimentalFeatures: boolean
     showHelpButtons: boolean
+    showPanel: boolean | null
     sidebarExpanded: boolean
     sidebarScrollable: boolean
   }

--- a/packages/devtools/client/pages/index.vue
+++ b/packages/devtools/client/pages/index.vue
@@ -6,9 +6,16 @@ definePageMeta({
 })
 
 const telemetry = ref(true)
+const enableFloatPanel = ref(true)
+
+const {
+  showPanel,
+} = useDevToolsUIOptions()
 
 function visit() {
   telemetryEnabled.value = telemetry.value
+  if (showPanel.value == null && enableFloatPanel.value)
+    showPanel.value = true
   isFirstVisit.value = false
 }
 </script>
@@ -34,9 +41,14 @@ function visit() {
     </NButton>
 
     <div absolute bottom-0 left-0 right-0 p4>
-      <NCheckbox v-model="telemetry">
-        <span op50>Send anonymous statistics, help us improving DevTools</span>
-      </NCheckbox>
+      <div flex="~ col gap-2" mxa w-max>
+        <NCheckbox v-if="showPanel == null" v-model="enableFloatPanel" n="green6">
+          <span op50>Show floating panel from now on</span>
+        </NCheckbox>
+        <NCheckbox v-model="telemetry" n="green6">
+          <span op50>Send anonymous statistics, help us improving DevTools</span>
+        </NCheckbox>
+      </div>
     </div>
   </NPanelGrids>
 </template>

--- a/packages/devtools/client/pages/settings.vue
+++ b/packages/devtools/client/pages/settings.vue
@@ -7,7 +7,7 @@ definePageMeta({
 
 const {
   interactionCloseOnOutsideClick,
-  // showExperimentalFeatures,
+  showPanel,
   showHelpButtons,
   scale,
   hiddenTabs,
@@ -107,7 +107,7 @@ watchEffect(() => {
             <NSwitch
               flex="~ row-reverse" py1 pl2 pr1 n-lime
               :model-value="!hiddenTabCategories.includes(name)"
-              @update:model-value="v => toggleTabCategory(name, v)"
+              @update:model-value="(v: boolean) => toggleTabCategory(name, v)"
             >
               <div flex="~ gap-2" flex-auto items-center justify-start>
                 <span capitalize op75>{{ name }}</span>
@@ -120,7 +120,7 @@ watchEffect(() => {
               <NSwitch
                 flex="~ row-reverse" py1 pl2 pr1 n-primary
                 :model-value="!hiddenTabs.includes(tab.name)"
-                @update:model-value="v => toggleTab(tab.name, v)"
+                @update:model-value="(v: boolean) => toggleTab(tab.name, v)"
               >
                 <div flex="~ gap-2" flex-auto items-center justify-start pr-4 :class="hiddenTabs.includes(tab.name) ? 'op25' : ''">
                   <TabIcon text-xl :icon="tab.icon" :title="tab.title" />
@@ -197,10 +197,14 @@ watchEffect(() => {
             <span>Show help buttons</span>
           </NCheckbox>
 
+          <NCheckbox v-model="showPanel" n-primary>
+            <span>Always show the floating panel</span>
+          </NCheckbox>
+
           <div mx--2 my1 h-1px border="b base" op75 />
 
           <p>Minimize floating panel on inactive</p>
-          <NSelect v-model.number="minimizePanelInactive" n="primary">
+          <NSelect v-model.number="minimizePanelInactive" n-primary>
             <option v-for="i of MinimizeInactiveOptions" :key="i[0]" :value="i[1]">
               {{ i[0] }}
             </option>

--- a/packages/devtools/client/unocss.config.ts
+++ b/packages/devtools/client/unocss.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
   ],
   theme: {
     colors: {
-      primary: '#00DC82',
+      brand: '#00DC82',
+      primary: '#099e61',
     },
   },
   presets: [

--- a/packages/devtools/src/constant.ts
+++ b/packages/devtools/src/constant.ts
@@ -34,6 +34,7 @@ export const defaultTabOptions: NuxtDevToolsOptions = {
     interactionCloseOnOutsideClick: false,
     showExperimentalFeatures: false,
     showHelpButtons: true,
+    showPanel: null,
     scale: 1,
     minimizePanelInactive: 5000,
     hiddenTabs: [],

--- a/packages/devtools/src/runtime/settings.ts
+++ b/packages/devtools/src/runtime/settings.ts
@@ -1,0 +1,8 @@
+import type { NuxtDevToolsOptions } from '../types'
+
+// @ts-expect-error virtual module
+import _settings from '#build/devtools/settings'
+
+export const settings = _settings as {
+  ui: NuxtDevToolsOptions['ui']
+}


### PR DESCRIPTION
When we ship DevTools by default in Nuxt 3, we want to minimize the distribution for regular development workflow as much as possible. In that case, we don't want all users to get the floating panel in their apps without knowing the existence of Nuxt DevTools.

In this PR, we make the panel hide by default, except when `devtools: { enabled: true }` or `modules: ['@nuxt/devtools']` is presented in the config (indicate that the users are aware of and want to use devtools).

Combining with https://github.com/nuxt/devtools/commit/97b3e186e8798142c54d2599329ca97c97ea4b59, we are showing the hint in both the terminal and browser console. For the first time a user opens up DevTools, a welcome page will be displayed and ask to turn on the floating panel.