### PR TITLE
fix(assets): watcher

### DIFF
--- a/packages/devtools/src/server-rpc/assets.ts
+++ b/packages/devtools/src/server-rpc/assets.ts
@@ -17,7 +17,7 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh }: NuxtDevtoo
   }, 500)
 
   nuxt.hook('builder:watch', (event, key) => {
-    if (key.startsWith(publicDir) && (event === 'add' || event === 'unlink'))
+    if (key.startsWith(nuxt.options.dir.public) && (event === 'add' || event === 'unlink'))
       refreshDebounced()
   })
 


### PR DESCRIPTION
I think before the watch hook key had srcDir with it, but now it is only the publicDir (e.g. public/nuxt.svg) so watcher was not working.