### PR TITLE
chore: typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please refer to the [Contribution Guide](https://devtools.nuxt.com/development/contributing) on our documentation.
+Please refer to the [Contribution Guide](https://devtools.nuxt.com/development/contributing) in our documentation.


### PR DESCRIPTION
'in' our documentation