### PR TITLE
docs: typo

### DIFF
--- a/packages/devtools/client/components/docs/imports.md
+++ b/packages/devtools/client/components/docs/imports.md
@@ -1,6 +1,6 @@
 # Auto imports
 
-Nuxt auto-imports helper functions, composables and Vue APIs to use across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own components, composables and plugins. Components, composables or plugins can use these functions.
+Nuxt auto-imports helper functions, composables and Vue APIs to be used across your application without explicitly importing them. Based on the directory structure, every Nuxt application can also use auto-imports for its own components, composables and plugins. Components, composables or plugins can use these functions.
 
 <hr>
 
@@ -14,4 +14,4 @@ Meanwhile, modules could also provide auto-imports for their own components. You
 
 <hr>
 
-[Learn more on the documentation](https://nuxt.com/docs/guide/concepts/auto-imports)
+[Learn more in the documentation](https://nuxt.com/docs/guide/concepts/auto-imports)


### PR DESCRIPTION
'in' the documentation