### PR TITLE
chore(timeline): add linebreaks to transform

### DIFF
--- a/packages/devtools/src/integrations/timeline.ts
+++ b/packages/devtools/src/integrations/timeline.ts
@@ -67,7 +67,7 @@ export async function setup({ nuxt, options }: NuxtDevtoolsServerContext) {
                 : `import { __nuxtTimelineWrap } from ${JSON.stringify(helperPath)}`,
               ...injected.map(i => `const ${i.meta!.wrapperOriginalAs} = __nuxtTimelineWrap(${JSON.stringify(i.name)}, ${i.as})`),
               '',
-            ].join(';')
+            ].join(';\n')
             return result
           }
         },


### PR DESCRIPTION
Instead of concatenating all additions in a single line, the additions are split to one line each. This makes the transform's result easier to read:

```ts
import { __nuxtTimelineWrap } from "/...../node_modules/.pnpm/@nuxt+devtools@1.0.0_nuxt@3.8.0_rollup@2.79.1_vite@4.5.0/node_modules/@nuxt/devtools/dist/runtime/function-metrics-helpers";
const abortNavigation = __nuxtTimelineWrap("abortNavigation", _$__abortNavigation);
const useNuxtApp = __nuxtTimelineWrap("useNuxtApp", _$__useNuxtApp);
const useRoute = __nuxtTimelineWrap("useRoute", _$__useRoute);
const useGetBreadcrumbItemProps = __nuxtTimelineWrap("useGetBreadcrumbItemProps", _$__useGetBreadcrumbItemProps);
const useHeadDefault = __nuxtTimelineWrap("useHeadDefault", _$__useHeadDefault);
```
instead of

```ts
import { __nuxtTimelineWrap } from "/...../node_modules/.pnpm/@nuxt+devtools@1.0.0_nuxt@3.8.0_rollup@2.79.1_vite@4.5.0/node_modules/@nuxt/devtools/dist/runtime/function-metrics-helpers";const abortNavigation = __nuxtTimelineWrap("abortNavigation", _$__abortNavigation);const useNuxtApp = __nuxtTimelineWrap("useNuxtApp", _$__useNuxtApp);const useRoute = __nuxtTimelineWrap("useRoute", _$__useRoute);const useGetBreadcrumbItemProps = __nuxtTimelineWrap("useGetBreadcrumbItemProps", _$__useGetBreadcrumbItemProps);const useHeadDefault = __nuxtTimelineWrap("useHeadDefault", _$__useHeadDefault);
```