### PR TITLE
fix(assets): remove dot from file extension

### DIFF
--- a/packages/devtools/src/server-rpc/assets.ts
+++ b/packages/devtools/src/server-rpc/assets.ts
@@ -104,7 +104,7 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
 
           const { ext } = parse(finalPath)
           if (extensions !== '*') {
-            if (!extensions.includes(ext.toLowerCase()))
+            if (!extensions.includes(ext.toLowerCase().slice(1)))
               throw new Error(`File extension ${ext} is not allowed to upload, allowed extensions are: ${extensions.join(', ')}\nYou can configure it in Nuxt config at \`devtools.assets.uploadExtensions\`.`)
           }
 


### PR DESCRIPTION
`.` from `ext` was blocking `defaultAllowedExtensions` to gt upload.
> sorry I forgot to add `.slice(1)` in the main PR #391 


note: sometimes there are some small fixes(or mistakes like this), should I open PR or commit directly? \cc @antfu 