### PR TITLE
docs: add `nuxt-mongoose` to examples

### DIFF
--- a/docs/content/2.module/0.guide.md
+++ b/docs/content/2.module/0.guide.md
@@ -188,3 +188,4 @@ Here are a few examples of how to integrate Nuxt DevTools in modules:
 - [UnoCSS Inspector](https://github.com/unocss/unocss/blob/25021a751494e99e85cfd82cca3855cdf78f6a12/packages/nuxt/src/index.ts#L81-L94)
 - [Nuxt Vitest runner](https://github.com/danielroe/nuxt-vitest/blob/7bac68d96f27dea6c30c198b7caaaf0b495574ab/packages/nuxt-vitest/src/module.ts#L139-L181)
 - [Nuxt OG Image Playground](https://github.com/harlan-zw/nuxt-og-image/blob/main/src/module.ts#L136)
+- [Nuxt Mongoose](https://github.com/arashsheyda/nuxt-mongoose/blob/main/src/devtools.ts)


### PR DESCRIPTION
added `nuxt-mongoose` as an example, also should we add [`nuxt-devtools-pinia`](https://www.npmjs.com/package/nuxt-devtools-pinia) too ?