### PR TITLE
feat(devtools): support for xdg-home-config

### DIFF
--- a/packages/devtools/src/dev-auth.ts
+++ b/packages/devtools/src/dev-auth.ts
@@ -10,7 +10,7 @@ export async function getDevAuthToken() {
   if (token)
     return token
 
-  const home = homedir()
+  const home = process.env.XDG_CONFIG_HOME || homedir()
   const dir = join(home, '.nuxt/devtools')
   const filepath = join(dir, 'dev-auth-token.txt')
 

--- a/packages/devtools/src/dev-auth.ts
+++ b/packages/devtools/src/dev-auth.ts
@@ -1,8 +1,8 @@
-import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import { randomStr } from '@antfu/utils'
+import { getHomeDir } from './utils/local-options'
 
 let token: string | undefined
 
@@ -10,7 +10,7 @@ export async function getDevAuthToken() {
   if (token)
     return token
 
-  const home = process.env.XDG_CONFIG_HOME || homedir()
+  const home = getHomeDir()
   const dir = join(home, '.nuxt/devtools')
   const filepath = join(dir, 'dev-auth-token.txt')
 

--- a/packages/devtools/src/utils/local-options.ts
+++ b/packages/devtools/src/utils/local-options.ts
@@ -10,6 +10,10 @@ interface LocalOptionSearchOptions {
   key?: string | boolean
 }
 
+export function getHomeDir() {
+  return process.env.XDG_CONFIG_HOME || homedir()
+}
+
 export async function readLocalOptions<T>(defaults: T, options: LocalOptionSearchOptions): Promise<T> {
   const { filePath } = getOptionsFilepath(options)
 
@@ -40,7 +44,7 @@ function getOptionsFilepath(options: LocalOptionSearchOptions) {
   else
     hashedKey = hash(options.root)
 
-  const home = process.env.XDG_CONFIG_HOME || homedir()
+  const home = getHomeDir()
   const filePath = join(home, '.nuxt/devtools', `${hashedKey}.json`)
 
   return {

--- a/packages/devtools/src/utils/local-options.ts
+++ b/packages/devtools/src/utils/local-options.ts
@@ -34,11 +34,15 @@ export async function readLocalOptions<T>(defaults: T, options: LocalOptionSearc
 
 function getOptionsFilepath(options: LocalOptionSearchOptions) {
   let hashedKey
+
   if (options.key)
     hashedKey = hash(`${options.root}:${options.key}`)
   else
     hashedKey = hash(options.root)
-  const filePath = join(homedir(), '.nuxt/devtools', `${hashedKey}.json`)
+
+  const home = process.env.XDG_CONFIG_HOME || homedir()
+  const filePath = join(home, '.nuxt/devtools', `${hashedKey}.json`)
+
   return {
     filePath,
     hashedKey,


### PR DESCRIPTION
* Issue #493 

Add support for XDG_CONFIG_HOME env variable. 

If detected, local options will be saved under `XDG_CONFIG_HOME/.nuxt/devtools`. If not, `homedir()/.nuxt/devtools` will be used (current behaviour).


