### PR TITLE
fix(devtools): don't enable devtools when in test mode

### DIFF
--- a/packages/devtools/src/integrations/plugin-metrics.ts
+++ b/packages/devtools/src/integrations/plugin-metrics.ts
@@ -1,7 +1,7 @@
 import type { NuxtDevtoolsServerContext } from '../types'
 
 export async function setup({ nuxt }: NuxtDevtoolsServerContext) {
-  if (!nuxt.options.dev)
+  if (!nuxt.options.dev || nuxt.options.test)
     return
 
   /**

--- a/packages/devtools/src/integrations/vue-inspector.ts
+++ b/packages/devtools/src/integrations/vue-inspector.ts
@@ -4,7 +4,7 @@ import VueInspector from 'vite-plugin-vue-inspector'
 import type { NuxtDevtoolsServerContext } from '../types'
 
 export async function setup({ nuxt, options }: NuxtDevtoolsServerContext) {
-  if (!nuxt.options.dev)
+  if (!nuxt.options.dev || nuxt.options.test)
     return
 
   addVitePlugin(VueInspector({

--- a/packages/devtools/src/module-main.ts
+++ b/packages/devtools/src/module-main.ts
@@ -27,7 +27,7 @@ export async function enableModule(options: ModuleOptions, nuxt: Nuxt) {
     return
   }
 
-  if (!nuxt.options.dev) {
+  if (!nuxt.options.dev || nuxt.options.test) {
     if (nuxt.options.build.analyze)
       await import('./integrations/analyze-build').then(({ setup }) => setup(nuxt, options))
     return

--- a/playgrounds/module-starter/playground/nuxt.config.ts
+++ b/playgrounds/module-starter/playground/nuxt.config.ts
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
      */
     defineNuxtModule({
       setup(_, nuxt) {
-        if (!nuxt.options.dev)
+        if (!nuxt.options.dev || nuxt.options.test)
           return
 
         const _process = startSubprocess(


### PR DESCRIPTION
I think we can skip devtools integration in a test context.