### PR TITLE
fix: stable integrations setup to have consistent plugins order

### DIFF
--- a/packages/devtools/src/integrations/plugin-metrics.ts
+++ b/packages/devtools/src/integrations/plugin-metrics.ts
@@ -1,9 +1,6 @@
 import type { NuxtDevtoolsServerContext } from '../types'
 
-export async function setup({ nuxt }: NuxtDevtoolsServerContext) {
-  if (!nuxt.options.dev || nuxt.options.test)
-    return
-
+export function setup({ nuxt }: NuxtDevtoolsServerContext) {
   /**
    * Wrap plugins with performance metrics
    */

--- a/packages/devtools/src/integrations/timeline.ts
+++ b/packages/devtools/src/integrations/timeline.ts
@@ -4,7 +4,7 @@ import semver from 'semver'
 import type { NuxtDevtoolsServerContext } from '../types'
 import { runtimeDir } from '../dirs'
 
-export async function setup({ nuxt, options }: NuxtDevtoolsServerContext) {
+export function setup({ nuxt, options }: NuxtDevtoolsServerContext) {
   const helperPath = resolve(runtimeDir, 'function-metrics-helpers')
 
   const includeFrom = options.timeline?.functions?.includeFrom || [

--- a/packages/devtools/src/integrations/vite-inspect.ts
+++ b/packages/devtools/src/integrations/vite-inspect.ts
@@ -4,7 +4,7 @@ import Inspect from 'vite-plugin-inspect'
 import { addCustomTab } from '@nuxt/devtools-kit'
 import type { NuxtDevtoolsServerContext } from '../types'
 
-export async function setup({ nuxt, rpc }: NuxtDevtoolsServerContext) {
+export function setup({ nuxt, rpc }: NuxtDevtoolsServerContext) {
   const plugin = Inspect()
   addVitePlugin(plugin)
 

--- a/packages/devtools/src/integrations/vue-inspector.ts
+++ b/packages/devtools/src/integrations/vue-inspector.ts
@@ -3,10 +3,7 @@ import type { Plugin } from 'vite'
 import VueInspector from 'vite-plugin-vue-inspector'
 import type { NuxtDevtoolsServerContext } from '../types'
 
-export async function setup({ nuxt, options }: NuxtDevtoolsServerContext) {
-  if (!nuxt.options.dev || nuxt.options.test)
-    return
-
+export function setup({ options }: NuxtDevtoolsServerContext) {
   addVitePlugin(VueInspector({
     toggleComboKey: '',
     ...typeof options.componentInspector === 'boolean'

--- a/packages/devtools/src/module-main.ts
+++ b/packages/devtools/src/module-main.ts
@@ -19,7 +19,7 @@ import { readLocalOptions } from './utils/local-options'
 
 export async function enableModule(options: ModuleOptions, nuxt: Nuxt) {
   // Disable in test mode
-  if (process.env.TEST || process.env.NODE_ENV === 'test')
+  if (process.env.TEST || process.env.NODE_ENV === 'test' || nuxt.options.test)
     return
 
   if (nuxt.options.builder !== '@nuxt/vite-builder') {
@@ -27,7 +27,7 @@ export async function enableModule(options: ModuleOptions, nuxt: Nuxt) {
     return
   }
 
-  if (!nuxt.options.dev || nuxt.options.test) {
+  if (!nuxt.options.dev) {
     if (nuxt.options.build.analyze)
       await import('./integrations/analyze-build').then(({ setup }) => setup(nuxt, options))
     return
@@ -178,14 +178,15 @@ window.__NUXT_DEVTOOLS_TIME_METRIC__.appInit = Date.now()
     })
   })
 
+  await import('./integrations/plugin-metrics').then(({ setup }) => setup(ctx))
+
+  if (options.viteInspect !== false)
+    await import('./integrations/vite-inspect').then(({ setup }) => setup(ctx))
+
+  if (options.componentInspector !== false)
+    await import('./integrations/vue-inspector').then(({ setup }) => setup(ctx))
+
   const integrations = [
-    import('./integrations/plugin-metrics').then(({ setup }) => setup(ctx)),
-    options.viteInspect !== false
-      ? import('./integrations/vite-inspect').then(({ setup }) => setup(ctx))
-      : null,
-    options.componentInspector !== false
-      ? import('./integrations/vue-inspector').then(({ setup }) => setup(ctx))
-      : null,
     options.vscode?.enabled
       ? import('./integrations/vscode').then(({ setup }) => setup(ctx))
       : null,


### PR DESCRIPTION
Running them in parallel makes the plugin list not stable across multiple runs. This is one of the reasons causing Vite to have an unstable hash that invalidates the cache on every run (https://github.com/nuxt/nuxt/issues/24196#issuecomment-1853505843)