### PR TITLE
fix(devtools): update default types to `module.d.ts`/`.mts`

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -11,7 +11,7 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/module.d.ts",
+      "types": "./dist/module.d.mts",
       "import": "./dist/module.mjs",
       "require": "./module.cjs"
     },
@@ -21,7 +21,7 @@
     "./*": "./*"
   },
   "main": "./module.cjs",
-  "types": "./dist/types.d.ts",
+  "types": "./dist/module.d.ts",
   "bin": "./cli.mjs",
   "files": [
     "*.cjs",


### PR DESCRIPTION
when accessing type completion for `devtools` it is typed as `any` because there is no default export in `dist/types.d.ts`.

When using bundler module resolution, it works fine as the types file is `dist/module.d.ts` instead.