### PR TITLE
fix(timeline-helper-wrapper): Fix return value in timeline wrapper for promises

### DIFF
--- a/packages/devtools/src/runtime/function-metrics-helpers.ts
+++ b/packages/devtools/src/runtime/function-metrics-helpers.ts
@@ -76,12 +76,13 @@ export function __nuxtTimelineWrap(name: string, fn: any) {
     try {
       if (result && typeof result.then === 'function') {
         event.isPromise = true
-        return result
+        result
           .then((i: any) => i)
           .finally(() => {
             event.end = Date.now()
             return result
           })
+        return result
       }
     }
     catch (e) {}


### PR DESCRIPTION
This PR fixes bug of usage `timeline` option with `useAsyncData` with `lazy: true`

### Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### Description

Case if bug:
- `useAsyncData` returns only promise, without data, pending and others

### Reproduction
- [Reproduction branch](https://github.com/Vespand/devtools/tree/fix/timeline-helper-wrapper-reproduction) - added reproduction in `./playgrounds/empty` (JFI - it only works on local machine, in stackblitz timeline metrics can't be enabled)
- `useAsyncData()` return not only promise, it also return a lot additional attributes, like `data`, `pending`, `error`, example:
<img width="395" alt="image" src="https://github.com/nuxt/devtools/assets/36310479/888696ec-f651-4042-9308-a99d351dab0e">

- After use `useAsyncData()` with metrics wrapper returning value is only promise, example with timeline enabled:
<img width="411" alt="image" src="https://github.com/nuxt/devtools/assets/36310479/d286e3b6-f4a1-4dbd-b7d2-d49f54619158">

- Without `timeline: { enabled: true } }` all working as expected

This happens, because `.finally()` returns only Promise, without additional attributes, added by `useAsyncData()`

Looking for feedback about fix :)