### PR TITLE
feat(ui): added autocomplete props to NTextInput component

### DIFF
--- a/packages/devtools-ui-kit/playground/pages/index.vue
+++ b/packages/devtools-ui-kit/playground/pages/index.vue
@@ -202,6 +202,7 @@ const radio = ref('a')
               n="pink6 dark:pink5"
               icon="carbon:user"
               placeholder="Your name..."
+              autocomplete="username"
             />
             <NTextInput
               n="pink6 dark:pink5"
@@ -214,6 +215,7 @@ const radio = ref('a')
               icon="carbon:password"
               type="password"
               placeholder="Your password..."
+              autocomplete="current-password"
               required
             />
             <NButton class="self-start">

--- a/packages/devtools-ui-kit/src/components/NTextInput.vue
+++ b/packages/devtools-ui-kit/src/components/NTextInput.vue
@@ -8,6 +8,7 @@ const props = withDefaults(
     placeholder?: string
     disabled?: boolean
     autofocus?: boolean
+    autocomplete?: string
     readonly?: boolean
     type?: string
   }>(),


### PR DESCRIPTION
Pass autocompete attribute to input element.

That removes this warning :
![image](https://github.com/nuxt/devtools/assets/188172/406aa1be-925b-4bde-b309-b6c27d0161d5)