### PR TITLE
fix: floating-vue arrow style

### DIFF
--- a/packages/devtools/client/styles/global.css
+++ b/packages/devtools/client/styles/global.css
@@ -29,7 +29,7 @@ html.dark {
 .v-popper--theme-tooltip .v-popper__arrow-inner,
 .v-popper--theme-dropdown .v-popper__arrow-inner {
   visibility: visible;
-  --at-apply: border-white dark:border-hex-121212;
+  --at-apply: border-white 'dark:border-hex-121212';
 }
 
 .v-popper--theme-tooltip .v-popper__arrow-outer,

--- a/packages/devtools/client/styles/global.css
+++ b/packages/devtools/client/styles/global.css
@@ -29,7 +29,7 @@ html.dark {
 .v-popper--theme-tooltip .v-popper__arrow-inner,
 .v-popper--theme-dropdown .v-popper__arrow-inner {
   visibility: visible;
-  --at-apply: border-white dark: border-hex-121212;
+  --at-apply: border-white dark:border-hex-121212;
 }
 
 .v-popper--theme-tooltip .v-popper__arrow-outer,


### PR DESCRIPTION
A very very small fix, but which gave me a hard time struggling with eslint.
That fix the black arrow in light mode.
![image](https://github.com/nuxt/devtools/assets/188172/e5a4604f-f26c-4d58-a52f-a76442b41ce4)
