### PR TITLE
fix(ui): Added composable to build config

### DIFF
--- a/packages/devtools-ui-kit/build.config.ts
+++ b/packages/devtools-ui-kit/build.config.ts
@@ -6,6 +6,7 @@ export default defineBuildConfig({
     { input: 'src/module', format: 'esm' },
     { input: 'src/unocss', format: 'esm' },
     { input: 'src/components/', outDir: 'dist/components' },
+    { input: 'src/composables/', outDir: 'dist/composables' },
     { input: 'src/runtime/', outDir: 'dist/runtime' },
     { input: 'src/assets/', outDir: 'dist/assets' },
   ],


### PR DESCRIPTION
We can't export detvools-ui-kit in external project without the composables. It throw this error when including the component `NNotification` :
```bash
 ERROR  Pre-transform error: Failed to resolve import "../composables/notification" from "../../node_modules/.pnpm/@nuxt+devtools-ui-kit@1.0.8_@nuxt+devtools@1.0.8_@vue+compiler-core@3.4.5_fuse.js@7.0.0_idb-k_hp7eiil6i4mqmffgl7noc2tkui/node_modules/@nuxt/devtools-ui-kit/dist/components/NNotification.vue". Does the file exist?
```

This pull request fix this issue.
It doesn't seem to have an impact to the devtools client...