### PR TITLE
fix: floating-vue arrow style in dark

### DIFF
--- a/packages/devtools/client/styles/global.css
+++ b/packages/devtools/client/styles/global.css
@@ -29,8 +29,7 @@ html.dark {
 .v-popper--theme-tooltip .v-popper__arrow-inner,
 .v-popper--theme-dropdown .v-popper__arrow-inner {
   visibility: visible;
-  /* prettier-ignore */
-  --at-apply: border-white dark:border-hex-121212;
+  --at-apply: border-white dark-border-hex-121212;
 }
 
 .v-popper--theme-tooltip .v-popper__arrow-outer,

--- a/packages/devtools/client/styles/global.css
+++ b/packages/devtools/client/styles/global.css
@@ -29,7 +29,8 @@ html.dark {
 .v-popper--theme-tooltip .v-popper__arrow-inner,
 .v-popper--theme-dropdown .v-popper__arrow-inner {
   visibility: visible;
-  --at-apply: border-white 'dark:border-hex-121212';
+  /* prettier-ignore */
+  --at-apply: border-white dark:border-hex-121212;
 }
 
 .v-popper--theme-tooltip .v-popper__arrow-outer,


### PR DESCRIPTION
At #578, I fixed the light mode, but introduced a bug in dark mode!
The linter suggested to me to wrap with single quotes, but it breaks `--at-apply` at build time.
I double-checked light and dark mode for this pull request.
This tiny change gave me some headaches. I hope it's the last one! :disappointed_relieved: 