### PR TITLE
fix: remove unnecessary line + open devtools calling twice `syncClient`

### DIFF
--- a/packages/devtools/src/runtime/plugins/view/client.ts
+++ b/packages/devtools/src/runtime/plugins/view/client.ts
@@ -66,9 +66,6 @@ export async function setupDevToolsClient({
         if (state.value.open)
           return
         state.value.open = true
-        return nextTick(() => {
-          client.syncClient()
-        })
       },
       async navigate(path: string) {
         if (!state.value.open)
@@ -266,8 +263,6 @@ export async function setupDevToolsClient({
       })
     }
   }
-
-  client.syncClient()
 
   const holder = document.createElement('div')
   holder.id = 'nuxt-devtools-container'

--- a/packages/devtools/src/runtime/plugins/view/client.ts
+++ b/packages/devtools/src/runtime/plugins/view/client.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { computed, createApp, h, markRaw, nextTick, ref, shallowReactive, shallowRef, watch } from 'vue'
+import { computed, createApp, h, markRaw, ref, shallowReactive, shallowRef, watch } from 'vue'
 import { createHooks } from 'hookable'
 import { debounce } from 'perfect-debounce'
 import type { Router } from 'vue-router'


### PR DESCRIPTION
This pull request removes the line mentioned in #583 and fix the `open` issue.
In fact, the `watchEffect` in FrameBox.vue trigger when the `state.value.open` change and it will sync the client throw the `getIframe()` function. So, setting the `state.value.open` line 68 is enough to open the devtools. 