### PR TITLE
fix: inspect tab when custom buildAssetsDir is configured, fixes #589

### DIFF
--- a/packages/devtools/src/integrations/vite-inspect.ts
+++ b/packages/devtools/src/integrations/vite-inspect.ts
@@ -21,7 +21,7 @@ export function setup({ nuxt, rpc }: NuxtDevtoolsServerContext) {
     category: 'advanced',
     view: {
       type: 'iframe',
-      src: `${nuxt.options.app.baseURL}/_nuxt/__inspect/`.replace(/\/\//g, '/'),
+      src: `${nuxt.options.app.baseURL}/${nuxt.options.app.buildAssetsDir}/__inspect/`.replace(/\/\//g, '/'),
     },
   }), nuxt)
 


### PR DESCRIPTION
If there is a buildAssetsDir defined in the config the inspect tab in devtools throws 404 as the 'buildAssetsDir' is hardcoded.
![image](https://github.com/nuxt/devtools/assets/134087665/bbbba15d-3971-42ff-ba9a-213cb6f2da01)
![image](https://github.com/nuxt/devtools/assets/134087665/10c6620d-b407-4bba-aacd-caa52a44e01e)
