### PR TITLE
fix: provide a label for accessbility

### DIFF
--- a/packages/devtools/client/components/IframeView.vue
+++ b/packages/devtools/client/components/IframeView.vue
@@ -28,7 +28,7 @@ onMounted(() => {
   else {
     iframeEl.value = document.createElement('iframe')
     iframeEl.value.setAttribute('allow', allowedPermissions.join('; '))
-    iframe.value.setAttribute('aria-label','Nuxt Devtools')
+    iframeEl.value.setAttribute('aria-label','Nuxt Devtools')
 
     if (isPersistent)
       iframeCacheMap.set(key.value, iframeEl.value)

--- a/packages/devtools/client/components/IframeView.vue
+++ b/packages/devtools/client/components/IframeView.vue
@@ -28,6 +28,7 @@ onMounted(() => {
   else {
     iframeEl.value = document.createElement('iframe')
     iframeEl.value.setAttribute('allow', allowedPermissions.join('; '))
+    iframe.value.setAttribute('aria-label','Nuxt Devtools')
 
     if (isPersistent)
       iframeCacheMap.set(key.value, iframeEl.value)


### PR DESCRIPTION
This PR provides a default label to the iframe to not hurt accessibility score in development. This will hopefully improve DX by only letting the real errors show, as devtools are not included in production.