### PR TITLE
fix: override `tsx` dependency to known fixed version (broken on Node v18.19.0+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
     "vite-hot-client": "^0.2.3",
     "vue-tsc": "^1.8.27"
   },
+  "pnpm": {
+    "overrides": {
+      "tsx": " ^4.6.1"
+    }
+  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  tsx: ' ^4.6.1'
+
 importers:
 
   .:
@@ -6297,7 +6300,7 @@ packages:
     resolution: {integrity: sha512-tmaM9gfnSWqzePVJ5FJLYX9mMyE6ZevvOIvd1CMoMk2Fn1F3aKI/OQPjubS5wCIKlPpWfDfKFEtoslCNCiZJpQ==}
     hasBin: true
     dependencies:
-      tsx: 4.1.1
+      tsx: 4.7.1
     dev: true
 
   /espree@10.0.0:
@@ -10929,14 +10932,13 @@ packages:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
-  /tsx@4.1.1:
-    resolution: {integrity: sha512-zyPn5BFMB0TB5kMLbYPNx4x/oL/oSlaecdKCv6WeJ0TeSEfx8RTJWjuB5TZ2dSewktgfBsBO/HNA9mrMWqLXMA==}
+  /tsx@4.7.1:
+    resolution: {integrity: sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
-      esbuild: 0.18.20
+      esbuild: 0.19.11
       get-tsconfig: 4.7.2
-      source-map-support: 0.5.21
     optionalDependencies:
       fsevents: 2.3.3
     dev: true


### PR DESCRIPTION
# Issue

Attempting to follow the [Contribution Guide](https://devtools.nuxt.com/development/contributing#monorepo) and run:

>```sh
>pnpm i
>pnpm run build
>```

on a new clone of the project on Node v18.19.0+ will result in the following error message (after some logs):
```
 node:internal/process/esm_loader:40
       internalBinding('errors').triggerUncaughtException(
                                 ^
 Error: tsx must be loaded with --import instead of --loader
 The --loader flag was deprecated in Node v20.6.0
     at V (file://{project root}/node_modules/.pnpm/tsx@4.1.1/node_modules/tsx/dist/esm/index.mjs:1:1956)
     at Hooks.addCustomLoader (node:internal/modules/esm/hooks:202:24)
     at Hooks.register (node:internal/modules/esm/hooks:168:16)
     at async initializeHooks (node:internal/modules/esm/utils:167:5)
     at async customizedModuleWorker (node:internal/modules/esm/worker:104:24)
```

# Research

Looking into this:
1. I came across [this issue showing the same issue in Backstage](https://github.com/backstage/backstage/issues/21738),
2. in which I saw [this comment from one of their maintainers](https://github.com/backstage/backstage/issues/21738#issuecomment-1840747879), GitHub user `@freben` (thanks, Fredrik!),
3. which linked to [this section of the Node.js changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#esm-and-customization-hook-changes), which seems to confirm this is an issue with Node v18.19.0+.
4. I then looked at the `tsx` GitHub issues and found [this issue mentioning the same changelog](https://github.com/privatenumber/tsx/issues/421),
5. in which I found [this comment from the owner](https://github.com/privatenumber/tsx/issues/421#issuecomment-1832993023), `@privatenumber` (thanks, Hiroki!), saying the issue is fixed in v4.6.1 of `tsx`.

# The cause (error trace)

This `tsx` issue is indeed the cause in this repo.

1. [`pnpm run build` runs `pnpm -r --filter=\"./packages/**/*\" run build`](https://github.com/nuxt/devtools/blob/6fc1403/package.json#L12), which runs the build scripts in all packages in `packages/**/*`
2. [the `build` script in `packages/devtools` includes `esno scripts/prepare.ts`](https://github.com/nuxt/devtools/blob/6fc1403/packages/devtools/package.json#L33)
3. [the package `esno` is a thin wrapper around `tsx`](https://github.com/antfu/esno/blob/master/README.md?plain=1#L14),
4. [`esno` includes `tsx` in its `package.json`, but as `^4.1.0`](https://github.com/antfu/esno/blob/536b7ca/package.json#L15), which can (and does) resolve to versions earlier than the fixed v4.6.1

# The solution

This PR simply adds a PNPM override of `^v4.6.1` for the `tsx` package.

# Additional comments

It would be nice if the authors of `esno` fixed the issue in their `package.json`, but they don't seem to be open to this as [they have disabled issues on the `esno` repo and have told people to open issues in the `tsx` repo instead](https://github.com/antfu/esno/blob/master/README.md?plain=1#L16).