### PR TITLE
fix: devtools border-radius

### DIFF
--- a/packages/devtools/client/app.vue
+++ b/packages/devtools/client/app.vue
@@ -130,7 +130,7 @@ registerCommands(() => [
     >
       <SideNav v-show="!isUtilityView" of-x-hidden of-y-auto />
       <NuxtLayout>
-        <NSplitPane storage-key="devtools:split-screen-mode" :min-size="20" aaa>
+        <NSplitPane storage-key="devtools:split-screen-mode" :min-size="20">
           <template #left>
             <NuxtPage />
           </template>

--- a/packages/devtools/client/app.vue
+++ b/packages/devtools/client/app.vue
@@ -126,11 +126,11 @@ registerCommands(() => [
     <div
       v-else
       :class="isUtilityView ? 'flex' : sidebarExpanded ? 'grid grid-cols-[250px_1fr]' : 'grid grid-cols-[50px_1fr]'"
-      h-full h-screen of-hidden font-sans bg-base
+      h-full h-screen of-hidden rounded-xl font-sans bg-base
     >
       <SideNav v-show="!isUtilityView" of-x-hidden of-y-auto />
       <NuxtLayout>
-        <NSplitPane storage-key="devtools:split-screen-mode" :min-size="20">
+        <NSplitPane storage-key="devtools:split-screen-mode" :min-size="20" aaa>
           <template #left>
             <NuxtPage />
           </template>


### PR DESCRIPTION
Some tabs (precisely server routes and server-tasks, maybe more) were overflowing of the iframe.

I tried using `overflow: hidden` without success, but adjusting the border-radius match worked.

Before vs after:

![image](https://github.com/nuxt/devtools/assets/19751938/4c694372-05f0-4f23-aa34-b6d3715bd711)

![image](https://github.com/nuxt/devtools/assets/19751938/9c46b345-f7c0-46fb-ab5d-94025be4e89e)
