### PR TITLE
fix: scheduledTasks can be undefined

### DIFF
--- a/packages/devtools/src/server-rpc/server-tasks.ts
+++ b/packages/devtools/src/server-rpc/server-tasks.ts
@@ -38,7 +38,7 @@ export function setupServerTasksRPC({ nuxt, refresh }: NuxtDevtoolsServerContext
       }
       return {
         tasks: nitro.options.tasks,
-        scheduledTasks: Object.entries(nitro.options.scheduledTasks)
+        scheduledTasks: Object.entries(nitro.options.scheduledTasks ?? {})
           .reduce<Record<string, string[]>>((acc, [cron, tasks]) => {
             acc[cron] = Array.isArray(tasks) ? tasks : [tasks]
             return acc


### PR DESCRIPTION
Types provided by nitro don't reflect the situation on the shape of nitro tasks options. Here, `Object.entries(undefined)` throws an error.

I will update the types on Nitro after this PR.

Note: this PR doesn't need to be merged if the fix is provided upstream on nitro, this is just a patch in the meanwhile