### PR TITLE
fix(pinia): pinia module searching null safety

### DIFF
--- a/packages/devtools/client/pages/modules/pinia.vue
+++ b/packages/devtools/client/pages/modules/pinia.vue
@@ -10,7 +10,7 @@ definePageMeta({
   layout: 'full',
   show() {
     const configs = useServerConfig()
-    return () => configs.value?.modules?.some(item => (item as string | Array<unknown>).includes('@pinia/nuxt'))
+    return () => configs.value?.modules?.some(item => (item as string | Array<unknown>)?.includes('@pinia/nuxt'))
   },
 })
 </script>


### PR DESCRIPTION
it was throwing an error: `Uncaught (in promise) TypeError: Cannot read properties of null (reading 'includes')`
