### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/devtools/client/app.vue
+++ b/packages/devtools/client/app.vue
@@ -7,7 +7,7 @@ import { useEyeDropper } from '@vueuse/core'
 import { setupClientRPC } from './setup/client-rpc'
 import { splitScreenAvailable } from '~/composables/storage'
 
-if (process.client)
+if (import.meta.client)
   import('./setup/unocss-runtime')
 
 useHead({

--- a/packages/devtools/src/runtime/function-metrics-helpers.ts
+++ b/packages/devtools/src/runtime/function-metrics-helpers.ts
@@ -16,7 +16,7 @@ function getStacktrace() {
 }
 
 export function initTimelineMetrics(): TimelineMetrics {
-  if (process.server)
+  if (import.meta.server)
     return undefined!
 
   if (window.__NUXT_DEVTOOLS_TIMELINE_METRICS__)
@@ -45,7 +45,7 @@ export function initTimelineMetrics(): TimelineMetrics {
 const wrapperFunctions = new WeakMap<any, any>()
 
 export function __nuxtTimelineWrap(name: string, fn: any) {
-  if (process.server)
+  if (import.meta.server)
     return fn
   if (typeof fn !== 'function')
     return fn

--- a/packages/devtools/src/runtime/use-nuxt-devtools.ts
+++ b/packages/devtools/src/runtime/use-nuxt-devtools.ts
@@ -12,7 +12,7 @@ export function useNuxtDevTools(): Ref<NuxtDevtoolsHostClient | undefined> {
   if (!process.dev)
     return r
 
-  if (process.server)
+  if (import.meta.server)
     return r
 
   if (window.__NUXT_DEVTOOLS_HOST__) {


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)