### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/packages/devtools/src/server-rpc/assets.ts
+++ b/packages/devtools/src/server-rpc/assets.ts
@@ -1,3 +1,4 @@
+import { relative } from 'node:path'
 import fsp from 'node:fs/promises'
 import { parse } from 'node:path'
 import { join, resolve } from 'pathe'
@@ -21,6 +22,7 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
   }, 500)
 
   nuxt.hook('builder:watch', (event, key) => {
+    key = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, key))
     if (key.startsWith(nuxt.options.dir.public) && (event === 'add' || event === 'unlink'))
       refreshDebounced()
   })

--- a/packages/devtools/src/server-rpc/assets.ts
+++ b/packages/devtools/src/server-rpc/assets.ts
@@ -1,6 +1,5 @@
-import { relative } from 'node:path'
+import { parse, relative } from 'node:path'
 import fsp from 'node:fs/promises'
-import { parse } from 'node:path'
 import { join, resolve } from 'pathe'
 import { imageMeta } from 'image-meta'
 import { debounce } from 'perfect-debounce'
@@ -13,8 +12,8 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
   let cache: AssetInfo[] | null = null
 
   const extensions = options.assets?.uploadExtensions || defaultAllowedExtensions
-
   const publicDir = resolve(nuxt.options.srcDir, nuxt.options.dir.public)
+  const layerDirs = [publicDir, ...nuxt.options._layers.map(layer => resolve(layer.cwd, 'public'))]
 
   const refreshDebounced = debounce(() => {
     cache = null
@@ -32,39 +31,42 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
       return cache
 
     const baseURL = nuxt.options.app.baseURL
-    const files = await fg(['**/*'], {
-      cwd: publicDir,
-      onlyFiles: true,
-    })
+    const dirs: { layerDir: string, files: string[] }[] = []
 
-    function guessType(path: string): AssetType {
-      if (/\.(png|jpe?g|jxl|gif|svg|webp|avif|ico|bmp|tiff?)$/i.test(path))
-        return 'image'
-      if (/\.(mp4|webm|ogv|mov|avi|flv|wmv|mpg|mpeg|mkv|3gp|3g2|ts|mts|m2ts|vob|ogm|ogx|rm|rmvb|asf|amv|divx|m4v|svi|viv|f4v|f4p|f4a|f4b)$/i.test(path))
-        return 'video'
-      if (/\.(mp3|wav|ogg|flac|aac|wma|alac|ape|ac3|dts|tta|opus|amr|aiff|au|mid|midi|ra|rm|wv|weba|dss|spx|vox|tak|dsf|dff|dsd|cda)$/i.test(path))
-        return 'audio'
-      if (/\.(woff2?|eot|ttf|otf|ttc|pfa|pfb|pfm|afm)/i.test(path))
-        return 'font'
-      if (/\.(json[5c]?|te?xt|[mc]?[jt]sx?|md[cx]?|markdown)/i.test(path))
-        return 'text'
-      return 'other'
+    for (const layerDir of layerDirs) {
+      const files = await fg(['**/*'], {
+        cwd: layerDir,
+        onlyFiles: true,
+      })
+      dirs.push({ layerDir, files })
     }
 
-    cache = await Promise.all(files.map(async (path) => {
-      const filePath = resolve(publicDir, path)
-      const stat = await fsp.lstat(filePath)
-      return {
-        path,
-        publicPath: join(baseURL, path),
-        filePath,
-        type: guessType(path),
-        size: stat.size,
-        mtime: stat.mtimeMs,
-      }
-    }))
+    const uniquePaths = new Set()
+    cache = []
 
-    return cache
+    for (const { layerDir, files } of dirs) {
+      for (const path of files) {
+        const filePath = resolve(layerDir, path)
+        const stat = await fsp.lstat(filePath)
+        const fullPath = join(baseURL, path)
+
+        // Check if path already exists in uniquePaths set
+        if (!uniquePaths.has(fullPath)) {
+          cache.push({
+            path,
+            publicPath: fullPath,
+            filePath,
+            type: guessType(path),
+            size: stat.size,
+            mtime: stat.mtimeMs,
+            layer: publicDir !== layerDir ? layerDir : undefined,
+          })
+          uniquePaths.add(fullPath)
+        }
+      }
+    }
+
+    return cache.sort((a, b) => a.path.localeCompare(b.path))
   }
 
   return {
@@ -148,4 +150,18 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
       return await fsp.rename(oldPath, newPath)
     },
   } satisfies Partial<ServerFunctions>
+}
+
+function guessType(path: string): AssetType {
+  if (/\.(png|jpe?g|jxl|gif|svg|webp|avif|ico|bmp|tiff?)$/i.test(path))
+    return 'image'
+  if (/\.(mp4|webm|ogv|mov|avi|flv|wmv|mpg|mpeg|mkv|3gp|3g2|ts|mts|m2ts|vob|ogm|ogx|rm|rmvb|asf|amv|divx|m4v|svi|viv|f4v|f4p|f4a|f4b)$/i.test(path))
+    return 'video'
+  if (/\.(mp3|wav|ogg|flac|aac|wma|alac|ape|ac3|dts|tta|opus|amr|aiff|au|mid|midi|ra|rm|wv|weba|dss|spx|vox|tak|dsf|dff|dsd|cda)$/i.test(path))
+    return 'audio'
+  if (/\.(woff2?|eot|ttf|otf|ttc|pfa|pfb|pfm|afm)/i.test(path))
+    return 'font'
+  if (/\.(json[5c]?|te?xt|[mc]?[jt]sx?|md[cx]?|markdown)/i.test(path))
+    return 'text'
+  return 'other'
 }


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

