### PR TITLE
feat: hide devtools when printing

### DIFF
--- a/packages/devtools/src/runtime/plugins/view/Main.vue
+++ b/packages/devtools/src/runtime/plugins/view/Main.vue
@@ -555,4 +555,10 @@ onMounted(() => {
   background-image: linear-gradient(45deg, #00dc82, #36e4da, #0047e1);
   filter: blur(60px);
 }
+
+@media print {
+  #nuxt-devtools-anchor {
+    display: none;
+  }
+}
 </style>

--- a/packages/devtools/src/runtime/plugins/view/client.ts
+++ b/packages/devtools/src/runtime/plugins/view/client.ts
@@ -275,11 +275,6 @@ export async function setupDevToolsClient({
       client.devtools.toggle()
   })
 
-  const isPrinting = useIsPrinting()
-  watch(isPrinting, (value) => {
-    holder.style.display = value ? 'none' : ''
-  }, { immediate: true })
-
   const app = createApp({
     render: () => h(Main, { client }),
     devtools: {
@@ -342,15 +337,6 @@ export function useClientColorMode(): Ref<ColorScheme> {
   getSystemColor()
 
   return computed(() => explicitColor.value || systemColor.value || 'light')
-}
-
-function useIsPrinting() {
-  const isPrinting = ref(false)
-  const mediaQuery = window.matchMedia('print')
-  mediaQuery.addEventListener('change', (e) => {
-    isPrinting.value = e.matches
-  })
-  return isPrinting
 }
 
 function setupRouteTracking(timeline: TimelineMetrics, router: Router) {

--- a/packages/devtools/src/runtime/plugins/view/client.ts
+++ b/packages/devtools/src/runtime/plugins/view/client.ts
@@ -275,17 +275,10 @@ export async function setupDevToolsClient({
       client.devtools.toggle()
   })
 
-  // disable when printing
-  const isPrinting = window.matchMedia('print')
-  isPrinting.addEventListener('change', (e) => {
-    if (e.matches)
-      client.devtools.close()
-    else
-      client.devtools.open()
-  })
-
-  if (isPrinting.matches)
-    client.devtools.close()
+  const isPrinting = useIsPrinting()
+  watch(isPrinting, (value) => {
+    holder.style.display = value ? 'none' : ''
+  }, { immediate: true })
 
   const app = createApp({
     render: () => h(Main, { client }),
@@ -349,6 +342,15 @@ export function useClientColorMode(): Ref<ColorScheme> {
   getSystemColor()
 
   return computed(() => explicitColor.value || systemColor.value || 'light')
+}
+
+function useIsPrinting() {
+  const isPrinting = ref(false)
+  const mediaQuery = window.matchMedia('print')
+  mediaQuery.addEventListener('change', (e) => {
+    isPrinting.value = e.matches
+  })
+  return isPrinting
 }
 
 function setupRouteTracking(timeline: TimelineMetrics, router: Router) {

--- a/packages/devtools/src/runtime/plugins/view/client.ts
+++ b/packages/devtools/src/runtime/plugins/view/client.ts
@@ -275,6 +275,18 @@ export async function setupDevToolsClient({
       client.devtools.toggle()
   })
 
+  // disable when printing
+  const isPrinting = window.matchMedia('print')
+  isPrinting.addEventListener('change', (e) => {
+    if (e.matches)
+      client.devtools.close()
+    else
+      client.devtools.open()
+  })
+
+  if (isPrinting.matches)
+    client.devtools.close()
+
   const app = createApp({
     render: () => h(Main, { client }),
     devtools: {


### PR DESCRIPTION
Currently when printing a page in dev-mode with nuxt the holder to open the dev-tools will be printed as well which often results in additional empty pages containing just the holder.

Please let me know if I should adjust the approach to something else.