### PR TITLE
fix: sort items in fuse

### DIFF
--- a/packages/devtools/client/components/ModuleInstallList.vue
+++ b/packages/devtools/client/components/ModuleInstallList.vue
@@ -21,17 +21,25 @@ const sortingFactors: Record<typeof sortingOptions[number], SortingFunction<Modu
   updated: (a, b) => a.stats.publishedAt - b.stats.publishedAt,
 }
 
-const sortedItems = computed(() => collection.value?.slice()
-  .sort((a, b) => sortingFactors[selectedSortingOption.value](a, b) * (ascendingOrder.value ? 1 : -1)))
+const sortedItems = computed(() => collection.value
+  ?.toSorted((a, b) => sortingFactors[selectedSortingOption.value](a, b) * (ascendingOrder.value ? 1 : -1)))
 
 const search = ref('')
-const fuse = computed(() => new Fuse(sortedItems.value || [], {
+const fuse = computed(() => new Fuse(collection.value || [], {
   keys: [
     'name',
     'description',
     'npm',
     'category',
   ],
+  sortFn: (a, b) => {
+    const itemA = collection.value?.[a.idx]
+    const itemB = collection.value?.[b.idx]
+    if (itemA && itemB)
+      return sortingFactors[selectedSortingOption.value](itemA, itemB) * (ascendingOrder.value ? 1 : -1)
+    return (a.score - b.score)
+  },
+  threshold: 0.2,
 }))
 
 const items = computed(() => {
@@ -49,7 +57,6 @@ const items = computed(() => {
       icon="i-carbon-intent-request-create"
       text="Install Module"
     />
-
     <NNavbar v-model:search="search" no-padding px-6 pb-5 pt-2>
       <template #actions>
         <NDropdown direction="end" n="sm primary">


### PR DESCRIPTION
Add sortFn option in fuse.js to sorted search result in list by sorting options, also threshold option avoid to show less relevance modules, but not sure if 0.2 is an appropriate value(if no threshold basically all modules will be displayed and will break sorting options😇)

fixed #669 