### PR TITLE
fix: color mode

### DIFF
--- a/packages/devtools-ui-kit/package.json
+++ b/packages/devtools-ui-kit/package.json
@@ -44,7 +44,6 @@
     "@iconify-json/tabler": "^1.1.111",
     "@nuxt/devtools-kit": "workspace:*",
     "@nuxt/kit": "^3.11.2",
-    "@nuxtjs/color-mode": "^3.4.1",
     "@unocss/core": "^0.60.0",
     "@unocss/nuxt": "^0.60.0",
     "@unocss/preset-attributify": "^0.60.0",

--- a/packages/devtools-ui-kit/src/components/NDarkToggle.vue
+++ b/packages/devtools-ui-kit/src/components/NDarkToggle.vue
@@ -3,7 +3,9 @@ import { computed, nextTick } from 'vue'
 
 import { useColorMode } from '@vueuse/core'
 
-const mode = useColorMode()
+const mode = useColorMode({
+  storageKey: 'nuxt-devtools-color-mode',
+})
 const isDark = computed<boolean>({
   get() {
     return mode.value === 'dark'
@@ -69,7 +71,7 @@ const context = {
 </script>
 
 <template>
-  <ColorScheme tag="span">
+  <ClientOnly placeholder-tag="span">
     <slot v-bind="context" />
-  </ColorScheme>
+  </ClientOnly>
 </template>

--- a/packages/devtools-ui-kit/src/module.ts
+++ b/packages/devtools-ui-kit/src/module.ts
@@ -45,7 +45,6 @@ export default defineNuxtModule<ModuleOptions>({
     const resolver = createResolver(import.meta.url)
     await installModule(await resolver.resolvePath('@unocss/nuxt'))
     await installModule(await resolver.resolvePath('@vueuse/nuxt'))
-    await installModule(await resolver.resolvePath('@nuxtjs/color-mode'))
     await installModule(await resolver.resolvePath('v-lazy-show/nuxt'))
   },
 })

--- a/packages/devtools/client/components/ServerRouteDetails.vue
+++ b/packages/devtools/client/components/ServerRouteDetails.vue
@@ -545,7 +545,7 @@ const copy = useCopy()
         <JsonEditorVue
           v-else-if="selectedTabInput === 'json'"
           v-model="routeInputBodyJSON"
-          :class="[colorMode === 'dark' ? 'jse-theme-dark' : 'light']"
+          :class="colorMode === 'dark' ? 'jse-theme-dark' : 'light'"
           class="json-editor-vue of-auto text-sm outline-none"
           v-bind="$attrs"
           :mode="('text' as any)"

--- a/packages/devtools/client/components/ServerRouteDetails.vue
+++ b/packages/devtools/client/components/ServerRouteDetails.vue
@@ -14,6 +14,7 @@ const emit = defineEmits<{
 
 const [DefineDefaultInputs, UseDefaultInputs] = createReusableTemplate()
 
+const colorMode = useColorMode()
 const config = useServerConfig()
 const client = useClient()
 
@@ -544,7 +545,7 @@ const copy = useCopy()
         <JsonEditorVue
           v-else-if="selectedTabInput === 'json'"
           v-model="routeInputBodyJSON"
-          :class="[$colorMode.value === 'dark' ? 'jse-theme-dark' : 'light']"
+          :class="[colorMode === 'dark' ? 'jse-theme-dark' : 'light']"
           class="json-editor-vue of-auto text-sm outline-none"
           v-bind="$attrs"
           :mode="('text' as any)"

--- a/packages/devtools/client/components/ServerTaskDetails.vue
+++ b/packages/devtools/client/components/ServerTaskDetails.vue
@@ -16,6 +16,7 @@ const routeInputBodyJSON = ref<any>({ payload: {} })
 const { inputDefaults } = useDevToolsOptions('serverRoutes')
 const [DefineDefaultInputs, UseDefaultInputs] = createReusableTemplate()
 
+const colorMode = useColorMode()
 const config = useServerConfig()
 
 const response = reactive({
@@ -310,7 +311,7 @@ const copy = useCopy()
         <JsonEditorVue
           v-else-if="selectedTabInput === 'json'"
           v-model="routeInputBodyJSON"
-          :class="[$colorMode.value === 'dark' ? 'jse-theme-dark' : 'light']"
+          :class="[colorMode === 'dark' ? 'jse-theme-dark' : 'light']"
           class="json-editor-vue of-auto text-sm outline-none"
           v-bind="$attrs"
           :mode="('text' as any)"

--- a/packages/devtools/client/components/ServerTaskDetails.vue
+++ b/packages/devtools/client/components/ServerTaskDetails.vue
@@ -311,7 +311,7 @@ const copy = useCopy()
         <JsonEditorVue
           v-else-if="selectedTabInput === 'json'"
           v-model="routeInputBodyJSON"
-          :class="[colorMode === 'dark' ? 'jse-theme-dark' : 'light']"
+          :class="colorMode === 'dark' ? 'jse-theme-dark' : 'light'"
           class="json-editor-vue of-auto text-sm outline-none"
           v-bind="$attrs"
           :mode="('text' as any)"

--- a/packages/devtools/client/components/StateEditor.vue
+++ b/packages/devtools/client/components/StateEditor.vue
@@ -86,7 +86,7 @@ async function refresh() {
         v-bind="$attrs"
         class="json-editor-vue"
         :class="[
-          colorMode.value === 'dark' ? 'jse-theme-dark' : '',
+          colorMode === 'dark' ? 'jse-theme-dark' : '',
           name ? '' : '',
         ]"
         :main-menu-bar="false"

--- a/packages/devtools/client/components/StorageDetails.vue
+++ b/packages/devtools/client/components/StorageDetails.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import JsonEditorVue from 'json-editor-vue'
 
+const colorMode = useColorMode()
 const nuxtApp = useNuxtApp()
 const router = useRouter()
 const searchString = ref('')
@@ -169,7 +170,7 @@ async function renameCurrentItem() {
         <JsonEditorVue
           v-if="typeof currentItem.content === 'object'"
           v-model="currentItem.updatedContent"
-          :class="[$colorMode.value === 'dark' ? 'jse-theme-dark' : 'light']"
+          :class="[colorMode === 'dark' ? 'jse-theme-dark' : 'light']"
           class="json-editor-vue h-full of-auto text-sm outline-none"
           v-bind="$attrs"
           :mode="('text' as any)"

--- a/packages/devtools/client/components/TimelineArgumentView.vue
+++ b/packages/devtools/client/components/TimelineArgumentView.vue
@@ -26,6 +26,7 @@ const OnSetup = defineComponent({
   },
 })
 
+const colorMode = useColorMode()
 const copy = useCopy()
 </script>
 
@@ -69,7 +70,7 @@ const copy = useCopy()
             v-bind="$attrs"
             class="json-editor-vue"
             :class="[
-              $colorMode.value === 'dark' ? 'jse-theme-dark' : '',
+              colorMode === 'dark' ? 'jse-theme-dark' : '',
             ]"
             :main-menu-bar="false"
             :navigation-bar="false"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -92,7 +92,6 @@
     "@nuxt/content": "^2.12.1",
     "@nuxt/devtools": "workspace:*",
     "@nuxt/test-utils": "3.9.0",
-    "@nuxtjs/color-mode": "^3.4.1",
     "@parcel/watcher": "^2.4.1",
     "@types/markdown-it-link-attributes": "^3.0.5",
     "@types/ua-parser-js": "^0.7.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,9 +249,6 @@ importers:
       '@nuxt/test-utils':
         specifier: 3.9.0
         version: 3.9.0(@vitest/ui@1.6.0(vitest@1.6.0))(h3@1.11.1)(rollup@4.14.1)(vite@5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4))(vitest@1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(sass@1.77.0)(terser@5.19.4))(vue-router@4.3.2(vue@3.4.27(typescript@5.4.5)))(vue@3.4.27(typescript@5.4.5))
-      '@nuxtjs/color-mode':
-        specifier: ^3.4.1
-        version: 3.4.1(rollup@4.14.1)
       '@parcel/watcher':
         specifier: ^2.4.1
         version: 2.4.1
@@ -323,7 +320,7 @@ importers:
         version: 1.0.37
       unocss:
         specifier: ^0.60.0
-        version: 0.60.0(@unocss/webpack@0.60.0(rollup@4.14.1))(postcss@8.4.38)(rollup@4.14.1)(vite@5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4))
+        version: 0.60.0(@unocss/webpack@0.60.0(rollup@4.14.1)(webpack@5.88.2))(postcss@8.4.38)(rollup@4.14.1)(vite@5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4))
       unplugin-vue-markdown:
         specifier: ^0.26.2
         version: 0.26.2(rollup@4.14.1)(vite@5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4))
@@ -409,9 +406,6 @@ importers:
       '@nuxt/kit':
         specifier: ^3.11.2
         version: 3.11.2(rollup@4.14.1)
-      '@nuxtjs/color-mode':
-        specifier: ^3.4.1
-        version: 3.4.1(rollup@4.14.1)
       '@unocss/core':
         specifier: ^0.60.0
         version: 0.60.0
@@ -450,7 +444,7 @@ importers:
         version: 3.1.5
       unocss:
         specifier: ^0.60.0
-        version: 0.60.0(@unocss/webpack@0.60.0(rollup@4.14.1))(postcss@8.4.38)(rollup@4.14.1)(vite@5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4))
+        version: 0.60.0(@unocss/webpack@0.60.0(rollup@4.14.1)(webpack@5.88.2))(postcss@8.4.38)(rollup@4.14.1)(vite@5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4))
       v-lazy-show:
         specifier: ^0.2.4
         version: 0.2.4(@vue/compiler-core@3.4.27)
@@ -1400,6 +1394,7 @@ packages:
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -1407,6 +1402,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@humanwhocodes/retry@0.2.3':
     resolution: {integrity: sha512-X38nUbachlb01YMlvPFojKoiXq+LzZvuSce70KPMPdeM1Rj03k4dR7lDslhbqXn3Ang4EU3+EAmwEAsbrjHW3g==}
@@ -1696,9 +1692,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
       vue: ^3.3.4
-
-  '@nuxtjs/color-mode@3.4.1':
-    resolution: {integrity: sha512-vZgJqDstxInGw3RGSWbLoCLXtU1mvh1LLeuEA/X3a++DYA4ifwSbNoiSiOyb9qZHFEwz1Xr99H71sXV4IhOaEg==}
 
   '@nuxtjs/mdc@0.6.1':
     resolution: {integrity: sha512-zS5QK7DZ/SBrjqQX1DOy7GnxKy+wbj2+LvooefOWmQqHfLTAqJLVIjuv/BmKnQWiRCq19+uysys3iY42EoY5/A==}
@@ -7364,7 +7357,7 @@ snapshots:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -7557,7 +7550,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -7914,7 +7907,7 @@ snapshots:
   '@eslint/eslintrc@3.0.2':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 10.0.1
       globals: 14.0.0
       ignore: 5.3.1
@@ -7956,7 +7949,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8000,7 +7993,7 @@ snapshots:
       '@antfu/install-pkg': 0.1.1
       '@antfu/utils': 0.7.8
       '@iconify/types': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       kolorist: 1.8.0
       local-pkg: 0.5.0
       mlly: 1.7.0
@@ -8053,7 +8046,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -8828,16 +8821,6 @@ snapshots:
       - vti
       - vue-tsc
 
-  '@nuxtjs/color-mode@3.4.1(rollup@4.14.1)':
-    dependencies:
-      '@nuxt/kit': 3.11.2(rollup@4.14.1)
-      pathe: 1.1.2
-      pkg-types: 1.1.1
-      semver: 7.6.2
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
   '@nuxtjs/mdc@0.6.1(rollup@4.14.1)':
     dependencies:
       '@nuxt/kit': 3.11.2(rollup@4.14.1)
@@ -8846,7 +8829,7 @@ snapshots:
       '@types/mdast': 4.0.3
       '@vue/compiler-core': 3.4.27
       consola: 3.2.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       defu: 6.1.4
       destr: 2.0.3
       detab: 3.0.2
@@ -10307,13 +10290,13 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -11132,6 +11115,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
+
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
@@ -11274,7 +11261,7 @@ snapshots:
   engine.io-client@6.5.2:
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       engine.io-parser: 5.2.1
       ws: 8.11.0
       xmlhttprequest-ssl: 2.0.0
@@ -11661,7 +11648,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       escape-string-regexp: 4.0.0
       eslint-scope: 8.0.1
       eslint-visitor-keys: 4.0.0
@@ -12310,14 +12297,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.0:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12339,14 +12326,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12411,7 +12398,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -13212,7 +13199,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -14923,7 +14910,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -14976,7 +14963,7 @@ snapshots:
   socket.io-client@4.7.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       engine.io-client: 6.5.2
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
@@ -14987,14 +14974,14 @@ snapshots:
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -15002,7 +14989,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -15340,7 +15327,7 @@ snapshots:
   tuf-js@2.2.0:
     dependencies:
       '@tufjs/models': 2.0.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       make-fetch-happen: 13.0.0
     transitivePeerDependencies:
       - supports-color
@@ -15873,7 +15860,7 @@ snapshots:
   vite-node@1.6.0(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.8(@types/node@20.12.11)(sass@1.77.0)(terser@5.19.4)
@@ -15933,7 +15920,7 @@ snapshots:
     dependencies:
       '@antfu/utils': 0.7.8
       '@rollup/pluginutils': 5.1.0(rollup@4.14.1)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       error-stack-parser-es: 0.1.1
       fs-extra: 11.2.0
       open: 10.1.0
@@ -16018,7 +16005,7 @@ snapshots:
       '@vitest/utils': 1.6.0
       acorn-walk: 8.3.2
       chai: 4.3.10
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.10


### PR DESCRIPTION
This PR fixes the glitch between darkMode and lightMode (closes #482) by removing `@nuxtjs/color-mode` and standardizing on `useColorMode` from `@vueuse`
- plus a custom storageKey (`nuxt-devtools-color-mode`) is now used for devtools.
