### PR TITLE
feat: add search functionality to components graph

### DIFF
--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -36,6 +36,7 @@ const {
 const selectedFilter = ref<ComponentRelationship>()
 
 const search = ref('')
+const searchDebounced = useDebounce(search, 300)
 
 const entries = computed(() => {
   const relations = (props.relationships || [])
@@ -91,7 +92,7 @@ const data = computed<Data>(() => {
         ? 'square'
         : 'dot'
 
-    const isGrayedOut = search.value && !rel.id.toLowerCase().includes(search.value.toLowerCase())
+    const isGrayedOut = searchDebounced.value && !rel.id.toLowerCase().includes(searchDebounced.value.toLowerCase())
 
     return {
       id: rel.id,
@@ -100,9 +101,9 @@ const data = computed<Data>(() => {
       shape,
       size: 15 + Math.min(rel.deps.length / 2, 8),
       font: {
-        color: isGrayedOut ? 'gray' : (colorMode.value === 'dark' ? 'white' : 'black'),
+        color: isGrayedOut ? '#8885' : (colorMode.value === 'dark' ? 'white' : 'black'),
       },
-      color: isGrayedOut ? 'gray' : selectedFilter.value?.id === rel.id ? '#82c742' : undefined,
+      color: isGrayedOut ? '#8885' : selectedFilter.value?.id === rel.id ? '#82c742' : undefined,
       // @ts-expect-error additional data
       extra: {
         id: rel.id,

--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -11,7 +11,9 @@ const props = defineProps<{
 
 const container = ref<HTMLElement>()
 const navbar = ref<HTMLElement>()
-const colorMode = useColorMode()
+const colorMode = useColorMode({
+  storageKey: 'nuxt-devtools-color-mode',
+})
 
 const selected = ref<{
   id: string
@@ -34,6 +36,8 @@ const {
 } = useDevToolsUIOptions()
 
 const selectedFilter = ref<ComponentRelationship>()
+
+const search = ref('')
 
 const entries = computed(() => {
   const relations = (props.relationships || [])
@@ -89,6 +93,8 @@ const data = computed<Data>(() => {
         ? 'square'
         : 'dot'
 
+    const isHighlighted = search.value && rel.id.toLowerCase().includes(search.value.toLowerCase())
+
     return {
       id: rel.id,
       label: path.split('/').splice(-1)[0].replace(/\.\w+$/, ''),
@@ -96,9 +102,9 @@ const data = computed<Data>(() => {
       shape,
       size: 15 + Math.min(rel.deps.length / 2, 8),
       font: {
-        color: colorMode.value === 'dark' ? 'white' : 'black',
+        color: isHighlighted ? (colorMode.value === 'dark' ? 'yellow' : 'purple') : (colorMode.value === 'dark' ? 'white' : 'black'),
       },
-      color: selectedFilter.value?.id === rel.id ? '#82c742' : undefined,
+      color: isHighlighted ? (colorMode.value === 'dark' ? 'yellow' : 'purple') : selectedFilter.value?.id === rel.id ? '#82c742' : undefined,
       // @ts-expect-error additional data
       extra: {
         id: rel.id,
@@ -200,8 +206,8 @@ function setFilter() {
 </script>
 
 <template>
-  <NNavbar ref="navbar" absolute left-0 right-0 top-0>
-    <template #search>
+  <NNavbar ref="navbar" v-model:search="search" absolute left-0 right-0 top-0>
+    <template #actions>
       <div flex="~ gap-4 wrap" w-full>
         <NCheckbox v-model="showPages" n="primary sm">
           <span op75>Show pages</span>

--- a/packages/devtools/client/components/ComponentsGraph.vue
+++ b/packages/devtools/client/components/ComponentsGraph.vue
@@ -102,9 +102,9 @@ const data = computed<Data>(() => {
       shape,
       size: 15 + Math.min(rel.deps.length / 2, 8),
       font: {
-        color: isHighlighted ? (colorMode.value === 'dark' ? 'yellow' : 'purple') : (colorMode.value === 'dark' ? 'white' : 'black'),
+        color: isHighlighted ? 'purple' : (colorMode.value === 'dark' ? 'white' : 'black'),
       },
-      color: isHighlighted ? (colorMode.value === 'dark' ? 'yellow' : 'purple') : selectedFilter.value?.id === rel.id ? '#82c742' : undefined,
+      color: isHighlighted ? 'purple' : selectedFilter.value?.id === rel.id ? '#82c742' : undefined,
       // @ts-expect-error additional data
       extra: {
         id: rel.id,


### PR DESCRIPTION
closes #693 

this PR adds highlighting functionality to component graph when a component is searched. the highlighted component will be shown in `purple`

| Dark Mode  | Light Mode |
| ------------- | ------------- |
| <img width="1687" alt="Screenshot 2024-07-21 at 7 11 08 PM" src="https://github.com/user-attachments/assets/8370bbce-5950-477c-9772-a92276a1332a">  | <img width="1679" alt="Screenshot 2024-07-21 at 7 10 42 PM" src="https://github.com/user-attachments/assets/2feb4583-146b-4963-9cff-6ce34d519321">
  