### PR TITLE
fix: welcome page showing after every page reload

### DIFF
--- a/packages/devtools/client/middleware/route.global.ts
+++ b/packages/devtools/client/middleware/route.global.ts
@@ -4,6 +4,6 @@ import { telemetryEnabled } from '~/composables/telemetry'
 export default defineNuxtRouteMiddleware((to) => {
   if (to.path === '/' && !(isFirstVisit.value || telemetryEnabled.value == null))
     return navigateTo('/modules/overview')
-  else if (to.path !== '/' && telemetryEnabled.value == null)
+  else if (to.path !== '/' && isFirstVisit.value)
     return navigateTo('/')
 })


### PR DESCRIPTION
### 🔗 Linked issue

I am assuming that what part of this issue meant: https://github.com/nuxt/devtools/issues/717. 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Even after accepting the Welcome screen once, it would show up again after every page reload (which is quite annoying while developing)

![nuxt-constant-welcome](https://github.com/user-attachments/assets/0179e202-5e74-4fb6-a019-917bfadd2d61)

This update will only show the welcome screen until "Get started" is clicked, after that it won't show anymore: 

![nuxt-welcome-once](https://github.com/user-attachments/assets/210e36a3-0d37-4a10-9b0a-d0f185cd9ef0)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
