### PR TITLE
Update 0.getting-started.md with header for opening the devtools window

### DIFF
--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -29,7 +29,7 @@ You can opt-in Nuxt DevTools per-project by going to the project root and run:
 npx nuxi@latest devtools enable
 ```
 
-### Show the DevTools window
+### Open the DevTools Panel
 
 Restart your Nuxt server and open your app in browser. Click the Nuxt icon on the bottom (or press <kbd>Shift</kbd> + <kbd>Alt</kbd> / <kbd>⇧ Shift</kbd> + <kbd>⌥ Option</kbd> + <kbd>D</kbd>) to toggle the DevTools.
 

--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -29,6 +29,8 @@ You can opt-in Nuxt DevTools per-project by going to the project root and run:
 npx nuxi@latest devtools enable
 ```
 
+### Show the DevTools window
+
 Restart your Nuxt server and open your app in browser. Click the Nuxt icon on the bottom (or press <kbd>Shift</kbd> + <kbd>Alt</kbd> / <kbd>⇧ Shift</kbd> + <kbd>⌥ Option</kbd> + <kbd>D</kbd>) to toggle the DevTools.
 
 ::callout


### PR DESCRIPTION
Added header for showing devtools window

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I stumbled on this project as a new Nuxt developer. Took me 3 scans through the documentation to find how to open the devtools window.

Adding the header makes this clearer

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
