### PR TITLE
fix: add v4 compatibility version handeling for pages tab

### DIFF
--- a/packages/devtools/client/composables/utils.ts
+++ b/packages/devtools/client/composables/utils.ts
@@ -9,6 +9,7 @@ import { useSessionStorage } from '@vueuse/core'
 import { relative } from 'pathe'
 import { triggerRef } from 'vue'
 import { useClient } from './client'
+import { useServerConfig } from './state'
 
 export function isNodeModulePath(path: string) {
   return !!path.match(/[/\\]node_modules[/\\]/) || isPackageName(path)
@@ -182,4 +183,9 @@ export function refreshData() {
 
 export function reloadPage() {
   location.reload()
+}
+
+export function useNuxtCompatibilityVersion() {
+  const config = useServerConfig()
+  return config.value?.future.compatibilityVersion
 }

--- a/packages/devtools/client/pages/modules/pages.vue
+++ b/packages/devtools/client/pages/modules/pages.vue
@@ -3,7 +3,7 @@ import { definePageMeta } from '#imports'
 import { computed, onMounted, ref } from 'vue'
 import { useClient, useClientRoute, useClientRouter } from '~/composables/client'
 import { useLayouts, useMergedRouteList, useServerApp, useServerConfig } from '~/composables/state'
-import { useNuxtCompatibilityVersion } from '../../composables/utils'
+import { useNuxtCompatibilityVersion } from '~/composables/utils'
 
 definePageMeta({
   icon: 'carbon-tree-view-alt',

--- a/packages/devtools/client/pages/modules/pages.vue
+++ b/packages/devtools/client/pages/modules/pages.vue
@@ -3,6 +3,7 @@ import { definePageMeta } from '#imports'
 import { computed, onMounted, ref } from 'vue'
 import { useClient, useClientRoute, useClientRouter } from '~/composables/client'
 import { useLayouts, useMergedRouteList, useServerApp, useServerConfig } from '~/composables/state'
+import { useNuxtCompatibilityVersion } from '../../composables/utils'
 
 definePageMeta({
   icon: 'carbon-tree-view-alt',
@@ -59,6 +60,10 @@ function navigateToRoute(path: string) {
   router.value.push(path)
   routeInput.value = path
 }
+
+const compatibilityVersion = useNuxtCompatibilityVersion()
+
+const pagesPath = computed(() => `./${compatibilityVersion === 4 ? 'app/' : ''}pages/index.vue`)
 </script>
 
 <template>
@@ -164,7 +169,7 @@ function navigateToRoute(path: string) {
     icon="carbon-tree-view-alt"
     name="wizard-pages"
     title="Nuxt Routing"
-    description="Create `./pages/index.vue` to enable routing"
+    :description="`Create ${pagesPath} to enable routing`"
     :actions="[
       {
         label: 'Learn more',

--- a/packages/devtools/src/wizard/enable-pages.ts
+++ b/packages/devtools/src/wizard/enable-pages.ts
@@ -18,8 +18,9 @@ const route = useRoute()
 `
 
 export async function enablePages(nuxt: Nuxt) {
-  const pathApp = join(nuxt.options.srcDir, 'app.vue')
-  const pathPageIndex = join(nuxt.options.srcDir, 'pages/index.vue')
+  const baseDir = nuxt.options.future.compatibilityVersion === 4 ? nuxt.options.dir.app : nuxt.options.srcDir
+  const pathApp = join(baseDir, 'app.vue')
+  const pathPageIndex = join(baseDir, 'pages/index.vue')
 
   if (fs.existsSync(pathPageIndex)) {
     logger.warn('pages/index.vue already exists, skipping')

--- a/playgrounds/v4/.npmrc
+++ b/playgrounds/v4/.npmrc
@@ -1,0 +1,2 @@
+shamefully-hoist=true
+strict-peer-dependencies=false

--- a/playgrounds/v4/nuxt.config.ts
+++ b/playgrounds/v4/nuxt.config.ts
@@ -1,0 +1,12 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: [
+    '../../local',
+  ],
+
+  compatibilityDate: '2024-09-19',
+
+  future: {
+    compatibilityVersion: 4,
+  },
+})

--- a/playgrounds/v4/package.json
+++ b/playgrounds/v4/package.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.6.1",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  }
+}

--- a/playgrounds/v4/tsconfig.json
+++ b/playgrounds/v4/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // https://nuxt.com/docs/guide/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -982,6 +982,8 @@ importers:
         specifier: 'catalog:'
         version: 3.14.1592(@parcel/watcher@2.5.0)(@types/node@22.10.1)(encoding@0.1.13)(eslint@9.15.0(jiti@2.4.0))(ioredis@5.4.1)(magicast@0.3.5)(optionator@0.9.3)(rollup@4.27.4)(sass@1.77.4)(terser@5.19.4)(typescript@5.6.3)(vite@5.4.11(@types/node@22.10.1)(sass@1.77.4)(terser@5.19.4))(vue-tsc@2.1.10(typescript@5.6.3))
 
+  playgrounds/v4: {}
+
 packages:
 
   '@aashutoshrathi/word-wrap@1.2.6':


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
closes #734 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

this PR adds support for creating page in nuxt v4 app directory

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
