### PR TITLE
feat: improves vscode integration, support multiple backends

### DIFF
--- a/docs/content/1.guide/1.features.md
+++ b/docs/content/1.guide/1.features.md
@@ -90,7 +90,66 @@ Learn more about [Nitro Storage](https://nitro.unjs.io/guide/storage)
 
 The VS Code Server integration in Nuxt DevTools enhances your development experience by bringing the power of Visual Studio Code directly into your browser. With this feature, you can seamlessly edit and debug your Nuxt projects using the familiar interface of VS Code.
 
-To get started with VS Code Server, follow the installation instructions provided by [Code Server Installation Guide](https://coder.com/docs/code-server/latest/install)
+Nuxt DevTools supports the following ways of integrating with VS Code:
+
+### Connecting to an existing code-server instance 
+
+Set `reuseExistingServer` to true in runtime config for `devtools/vscode` and set the `port` option to specify a port (defalts to 3080):
+
+```ts
+  devtools: {
+    vscode: {
+      reuseExistingServer: true,
+      port: 3090
+    }
+  }
+```
+  
+### Running a code-server instance locally 
+
+You can use either the [Microsoft Visual Studio Code Server](https://code.visualstudio.com/docs/remote/vscode-server) (via the `code` or `code-server` cli tools) or the [Coder VS Code Server](https://coder.com/docs/code-server/latest/install) (via the `code-server` cli tool) by setting the `codeServer` parameter under `devtools/vscode` in the runtime configuration.
+
+Options for the codeServer parameter are:
+|Type|Option|
+|----|------|
+|MS Code CLI|`ms-code-cli`|
+|MS Code Server|`ms-code-server`|
+|Coder Code Server|`coder-code-server`|
+
+You can set the `port` parameter to listen on a specific port (default 3080) and you can set the `host` parameter if you need to listen on a particular host interface (useful for devcontainers or docker containers that listen on ipv6 by default).
+
+**Example**:
+
+```ts
+  devtools: {
+    vscode: {
+      codeServer: 'ms-code-server',
+      host: '0.0.0.0',
+      port: 3090
+    }
+  }
+```
+
+### Remotely via a MS VS Code server tunnel
+
+Set the `mode` option in `devtools/vscode` runtime configuration to `tunnel`. You can set the name of the tunnel to connect to using the `tunnel` option under `devtools/vscode/tunnel` in runtime configuration)
+
+```ts
+  devtools: {
+    vscode: {
+      mode: 'tunnel',
+      tunnel: {
+        name: 'my-tunnel-name'
+      }
+    }
+  }
+```
+
+### Code Server Installation Instructions 
+
+To get started with Microsoft VS Code Server, follow the installation instructions provided by [Microsoft Visual Studio Code Server](https://code.visualstudio.com/docs/remote/vscode-server)
+
+To get started with Coder Code Server, follow the installation instructions provided by [Code Server Installation Guide](https://coder.com/docs/code-server/latest/install)
 
 For more information on the benefits and features of VS Code Server, refer to [the official Visual Studio Code blog](https://code.visualstudio.com/blogs/2022/07/07/vscode-server)
 

--- a/docs/content/1.guide/1.features.md
+++ b/docs/content/1.guide/1.features.md
@@ -92,20 +92,22 @@ The VS Code Server integration in Nuxt DevTools enhances your development experi
 
 Nuxt DevTools supports the following ways of integrating with VS Code:
 
-### Connecting to an existing code-server instance 
+### Connecting to an existing code-server instance
 
 Set `reuseExistingServer` to true in runtime config for `devtools/vscode` and set the `port` option to specify a port (defalts to 3080):
 
-```ts
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
   devtools: {
     vscode: {
       reuseExistingServer: true,
       port: 3090
     }
   }
+})
 ```
-  
-### Running a code-server instance locally 
+
+### Running a code-server instance locally
 
 You can use either the [Microsoft Visual Studio Code Server](https://code.visualstudio.com/docs/remote/vscode-server) (via the `code` or `code-server` cli tools) or the [Coder VS Code Server](https://coder.com/docs/code-server/latest/install) (via the `code-server` cli tool) by setting the `codeServer` parameter under `devtools/vscode` in the runtime configuration.
 
@@ -120,7 +122,8 @@ You can set the `port` parameter to listen on a specific port (default 3080) and
 
 **Example**:
 
-```ts
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
   devtools: {
     vscode: {
       codeServer: 'ms-code-server',
@@ -128,13 +131,15 @@ You can set the `port` parameter to listen on a specific port (default 3080) and
       port: 3090
     }
   }
+})
 ```
 
 ### Remotely via a MS VS Code server tunnel
 
 Set the `mode` option in `devtools/vscode` runtime configuration to `tunnel`. You can set the name of the tunnel to connect to using the `tunnel` option under `devtools/vscode/tunnel` in runtime configuration)
 
-```ts
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
   devtools: {
     vscode: {
       mode: 'tunnel',
@@ -143,9 +148,10 @@ Set the `mode` option in `devtools/vscode` runtime configuration to `tunnel`. Yo
       }
     }
   }
+})
 ```
 
-### Code Server Installation Instructions 
+### Code Server Installation Instructions
 
 To get started with Microsoft VS Code Server, follow the installation instructions provided by [Microsoft Visual Studio Code Server](https://code.visualstudio.com/docs/remote/vscode-server)
 

--- a/packages/devtools-kit/src/_types/integrations.ts
+++ b/packages/devtools-kit/src/_types/integrations.ts
@@ -232,3 +232,10 @@ export interface ComponentWithRelationships {
   dependencies?: string[]
   dependents?: string[]
 }
+
+export interface CodeServerOptions {
+  codeBinary: string
+  launchArg: string
+  licenseTermsArg: string
+  connectionTokenArg: string
+}

--- a/packages/devtools-kit/src/_types/options.ts
+++ b/packages/devtools-kit/src/_types/options.ts
@@ -155,15 +155,20 @@ export interface VSCodeIntegrationOptions {
    */
   tunnel?: VSCodeTunnelOptions
 
-
   /**
    * Determines which binary and arguments to use for VS Code.
-   * 
-   * By default, uses the MS Code Server (ms-code-server). 
-   * Can alternatively use the open source Coder code-server (coder-code-server), 
+   *
+   * By default, uses the MS Code Server (ms-code-server).
+   * Can alternatively use the open source Coder code-server (coder-code-server),
    * or the MS VS Code CLI (ms-code-cli)
+   *  @default 'ms-code-server'
    */
   codeServer?: CodeServerType
+
+  /**
+   * Host address to listen on. Unspecified by default.
+   */
+  host?: string
 }
 
 export interface VSCodeTunnelOptions {

--- a/packages/devtools-kit/src/_types/options.ts
+++ b/packages/devtools-kit/src/_types/options.ts
@@ -4,6 +4,7 @@ import type { ModuleCustomTab } from './custom-tabs'
 import type { ServerRouteInfo, ServerRouteInput, ServerTaskInfo } from './integrations'
 
 export type CodeServerType = 'ms-code-cli' | 'ms-code-server' | 'coder-code-server'
+
 export interface ModuleOptions {
   /**
    * Enable DevTools

--- a/packages/devtools-kit/src/_types/options.ts
+++ b/packages/devtools-kit/src/_types/options.ts
@@ -3,6 +3,7 @@ import type { VitePluginInspectorOptions } from 'vite-plugin-vue-inspector'
 import type { ModuleCustomTab } from './custom-tabs'
 import type { ServerRouteInfo, ServerRouteInput, ServerTaskInfo } from './integrations'
 
+export type CodeServerType = 'ms-code-cli' | 'ms-code-server' | 'coder-code-server'
 export interface ModuleOptions {
   /**
    * Enable DevTools
@@ -153,6 +154,16 @@ export interface VSCodeIntegrationOptions {
    * Options for VS Code tunnel
    */
   tunnel?: VSCodeTunnelOptions
+
+
+  /**
+   * Determines which binary and arguments to use for VS Code.
+   * 
+   * By default, uses the MS Code Server (ms-code-server). 
+   * Can alternatively use the open source Coder code-server (coder-code-server), 
+   * or the MS VS Code CLI (ms-code-cli)
+   */
+  codeServer?: CodeServerType
 }
 
 export interface VSCodeTunnelOptions {

--- a/packages/devtools/src/integrations/vscode.ts
+++ b/packages/devtools/src/integrations/vscode.ts
@@ -69,6 +69,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
       '--accept-server-license-terms',
       '--install-extension',
       'antfu.vscode-server-controller',
+      '--host=0.0.0.0'
     ], { stderr: 'inherit', stdout: 'ignore', reject: false })
 
     startSubprocess(
@@ -79,6 +80,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
           '--accept-server-license-terms',
           '--without-connection-token',
           `--port=${port}`,
+          '--host=0.0.0.0'
         ],
       },
       {

--- a/packages/devtools/src/integrations/vscode.ts
+++ b/packages/devtools/src/integrations/vscode.ts
@@ -1,4 +1,4 @@
-import type { NuxtDevtoolsServerContext, CodeServerType } from '../types'
+import type { CodeServerOptions, CodeServerType, NuxtDevtoolsServerContext } from '../types'
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import { hostname } from 'node:os'
@@ -10,38 +10,31 @@ import { checkPort, getPort } from 'get-port-please'
 import which from 'which'
 import { LOG_PREFIX } from '../logger'
 
-
-type CodeServerOptions = {
-  codeBinary: string
-  launchArg: string
-  licenseTermsArg: string
-  connectionTokenArg: string
-}
 const codeBinaryOptions: Record<CodeServerType, CodeServerOptions> = {
   'ms-code-cli': {
     codeBinary: 'code',
     launchArg: 'serve-web',
     licenseTermsArg: '--accept-server-license-terms',
-    connectionTokenArg: '--without-connection-token'
+    connectionTokenArg: '--without-connection-token',
   },
-  "ms-code-server": {
-    codeBinary: "code-server",
-    launchArg: "serve-local",
-    licenseTermsArg: "--accept-server-license-terms",
-    connectionTokenArg: "--without-connection-token"
+  'ms-code-server': {
+    codeBinary: 'code-server',
+    launchArg: 'serve-local',
+    licenseTermsArg: '--accept-server-license-terms',
+    connectionTokenArg: '--without-connection-token',
   },
   'coder-code-server': {
     codeBinary: 'code-server',
     launchArg: 'serve-local',
     licenseTermsArg: '',
-    connectionTokenArg: ''
-  }
+    connectionTokenArg: '',
+  },
 }
 
-export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevtoolsServerContext) {  
+export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevtoolsServerContext) {
   const vsOptions = options?.vscode || {}
-  let codeServer: CodeServerType = vsOptions?.codeServer || 'ms-code-server';
-  let { codeBinary, launchArg, licenseTermsArg, connectionTokenArg } = codeBinaryOptions[codeServer];
+  const codeServer: CodeServerType = vsOptions?.codeServer || 'ms-code-server'
+  const { codeBinary, launchArg, licenseTermsArg, connectionTokenArg } = codeBinaryOptions[codeServer]
   const installed = !!await which(codeBinary).catch(() => null)
   let port = vsOptions?.port || 3080
   let url = `http://localhost:${port}`
@@ -60,7 +53,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
     // we can open files in VS Code Server
     try {
       const { port } = JSON.parse(await fs.readFile(vscodeServerControllerFile, 'utf-8')) as any
-      const url = `http://localhost:${port}/open?path=${encodeURIComponent(root + '/' + file)}`
+      const url = `http://localhost:${port}/open?path=${encodeURIComponent(`${root}/${file}`)}`
       await fetch(url)
       rpc.broadcast.navigateTo('/modules/custom-builtin-vscode')
       return true
@@ -97,7 +90,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
       licenseTermsArg,
       '--install-extension',
       'antfu.vscode-server-controller',
-      '--host=0.0.0.0'
+      '--host=0.0.0.0',
     ], { stderr: 'inherit', stdout: 'ignore', reject: false })
 
     startSubprocess(
@@ -108,7 +101,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
           licenseTermsArg,
           connectionTokenArg,
           `--port=${port}`,
-          '--host=0.0.0.0'
+          '--host=0.0.0.0',
         ],
       },
       {
@@ -174,7 +167,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
       icon: 'bxl-visual-studio',
       category: 'modules',
       requireAuth: true,
-      view: !installed && !(vsOptions?.mode === 'tunnel') 
+      view: !installed && !(vsOptions?.mode === 'tunnel')
         ? {
             type: 'launch',
             title: 'Install VS Code Server',

--- a/packages/devtools/src/integrations/vscode.ts
+++ b/packages/devtools/src/integrations/vscode.ts
@@ -32,7 +32,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
     // we can open files in VS Code Server
     try {
       const { port } = JSON.parse(await fs.readFile(vscodeServerControllerFile, 'utf-8')) as any
-      const url = `http://localhost:${port}/open?path=${encodeURIComponent(file)}`
+      const url = `http://localhost:${port}/open?path=${encodeURIComponent(root + "/" + file)}`
       await fetch(url)
       rpc.broadcast.navigateTo('/modules/custom-builtin-vscode')
       return true

--- a/packages/devtools/src/integrations/vscode.ts
+++ b/packages/devtools/src/integrations/vscode.ts
@@ -38,6 +38,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
   const installed = !!await which(codeBinary).catch(() => null)
   let port = vsOptions?.port || 3080
   let url = `http://localhost:${port}`
+  const host = vsOptions?.host ? `--host=${vsOptions.host}` : ''
   let loaded = false
   let promise: Promise<void> | null = null
   const mode = vsOptions?.mode || 'local-serve'
@@ -90,7 +91,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
       licenseTermsArg,
       '--install-extension',
       'antfu.vscode-server-controller',
-      '--host=0.0.0.0',
+      host,
     ], { stderr: 'inherit', stdout: 'ignore', reject: false })
 
     startSubprocess(
@@ -101,7 +102,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
           licenseTermsArg,
           connectionTokenArg,
           `--port=${port}`,
-          '--host=0.0.0.0',
+          host,
         ],
       },
       {

--- a/packages/devtools/src/integrations/vscode.ts
+++ b/packages/devtools/src/integrations/vscode.ts
@@ -87,11 +87,8 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
     // Install VS Code Server Controller
     // https://github.com/antfu/vscode-server-controller
     execa(codeBinary, [
-      launchArg,
-      licenseTermsArg,
       '--install-extension',
       'antfu.vscode-server-controller',
-      host,
     ], { stderr: 'inherit', stdout: 'ignore', reject: false })
 
     startSubprocess(

--- a/packages/devtools/src/server-rpc/general.ts
+++ b/packages/devtools/src/server-rpc/general.ts
@@ -177,7 +177,7 @@ export function setupGeneralRPC({
 
       try {
         for (const hook of openInEditorHooks) {
-          const result = await hook(path)
+          const result = await hook(path + suffix)
           if (result)
             return true
         }


### PR DESCRIPTION
### 🔗 Fixes

- fix #408
- fix #737
- fix #503 
- fix #750

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Improves support for VS Code integration:

1. Support both the newer Microsoft "code" cli tool (using serve-web) and the legacy vs-code-server cli tool. 
2. Adds a new option (`codeServer`) under the vscode options object to select the server type to use: `ms-code-server` for the legacy (and existing) code-server cli, `coder-code-server` for the open-source Coder code-server and `ms-code-cli` for the VS Code cli server. 
3. Adds the root path to the repository location when going to a file from the vue-inspector, solves issue when running in a container/devcontainer.
4. Adds host option ("0.0.0.0") to the arguments to support devcontainers that try to map to ipv6 addresses by default
5. Adds the line/column to the vue-inspector click url parameter so that vscode correctly goes to the right location when in the embedded devtool view.

```js
  devtools:{
      vscode:{
        codeServer: 'ms-code-cli', // or 'ms-code-server' or 'coder-code-server'
      }
  }
```
