### PR TITLE
Set a default value for the vscode host parameter

### DIFF
--- a/packages/devtools/src/integrations/vscode.ts
+++ b/packages/devtools/src/integrations/vscode.ts
@@ -38,7 +38,7 @@ export async function setup({ nuxt, options, openInEditorHooks, rpc }: NuxtDevto
   const installed = !!await which(codeBinary).catch(() => null)
   let port = vsOptions?.port || 3080
   let url = `http://localhost:${port}`
-  const host = vsOptions?.host ? `--host=${vsOptions.host}` : ''
+  const host = vsOptions?.host ? `--host=${vsOptions.host}` : '--host=127.0.0.1'
   let loaded = false
   let promise: Promise<void> | null = null
   const mode = vsOptions?.mode || 'local-serve'


### PR DESCRIPTION
### 🔗 Fixes

- fix #408
- fix #737
- fix #503 
- fix #750

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a bug in #763 - when the host parameter is not specified, the MS Code Server and MS Code CLI won't start (empty parameter is unrecognized). This change defaults the host to 127.0.0.1. 