### PR TITLE
feat: enhance module resolution paths for getPackageInfo

### DIFF
--- a/packages/devtools/src/npm/index.ts
+++ b/packages/devtools/src/npm/index.ts
@@ -14,7 +14,11 @@ export async function checkForUpdateOf(name: string, current?: string, nuxt = us
   try {
     if (!current) {
       const require = createRequire(nuxt.options.rootDir)
-      const info = await getPackageInfo(name, { paths: require.resolve.paths(name) || undefined })
+      const modulePaths = [
+        ...nuxt.options.modulesDir,
+        ...require.resolve.paths(name) || [],
+      ]
+      const info = await getPackageInfo(name, { paths: modulePaths })
       if (!info)
         return
       current = info.packageJson.version


### PR DESCRIPTION
### 🔗 Linked issue

resolves #598 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR enhances the DevTools method for checking package version information by incorporating Nuxt [modulesDir](https://nuxt.com/docs/api/nuxt-config#modulesdir) setting (`nuxt.options.modulesDir`), allowing it to check version information from additional custom module directories.
