### PR TITLE
perf: avoid unnecessary array copy in clipPath reversal

### DIFF
--- a/packages/devtools-ui-kit/src/components/NDarkToggle.vue
+++ b/packages/devtools-ui-kit/src/components/NDarkToggle.vue
@@ -49,7 +49,7 @@ function toggle(event?: MouseEvent) {
     document.documentElement.animate(
       {
         clipPath: isDark.value
-          ? [...clipPath].reverse()
+          ? clipPath.reverse()
           : clipPath,
       },
       {


### PR DESCRIPTION
Changed `[...clipPath].reverse()` to `clipPath.reverse()` to directly reverse the array in place. Since `reverse()` returns a new array and does not modify the original, this change simplifies the code without affecting behavior.