### PR TITLE
feat: filter out installed modules in search result, closes #780

### DIFF
--- a/packages/devtools/client/components/ModuleInstallList.vue
+++ b/packages/devtools/client/components/ModuleInstallList.vue
@@ -106,7 +106,7 @@ const items = computed(() => {
         <span op75>Filter installed</span>
       </NCheckbox>
       <div flex="~ gap1" text-sm op50>
-        <span v-if="search || installedFilter">{{ items.length }} matched · </span>
+        <span v-if="search || installedFilter">{{ items?.length }} matched · </span>
         <span>{{ collection?.length }} modules in total</span>
       </div>
     </NNavbar>

--- a/packages/devtools/client/components/ModuleInstallList.vue
+++ b/packages/devtools/client/components/ModuleInstallList.vue
@@ -100,11 +100,15 @@ const items = computed(() => {
               </span>
             </NButton>
           </div>
-        </NDropdown> {{ items?.length }}/{{ collection?.length }}
+        </NDropdown>
       </template>
       <NCheckbox v-model="installedFilter" n="primary md">
         <span op75>Filter installed</span>
       </NCheckbox>
+      <div flex="~ gap1" text-sm op50>
+        <span v-if="search || installedFilter">{{ items.length }} matched · </span>
+        <span>{{ collection?.length }} modules in total</span>
+      </div>
     </NNavbar>
 
     <div flex-auto of-auto flex="~ col gap-2" pl6 pr4>

--- a/packages/devtools/client/components/ModuleInstallList.vue
+++ b/packages/devtools/client/components/ModuleInstallList.vue
@@ -103,7 +103,7 @@ const items = computed(() => {
         </NDropdown>
       </template>
       <NCheckbox v-model="installedFilter" n="primary md">
-        <span op75>Filter installed</span>
+        <span op75>Hide installed modules</span>
       </NCheckbox>
       <div flex="~ gap1" text-sm op50>
         <span v-if="search || installedFilter">{{ items?.length }} matched · </span>

--- a/packages/devtools/client/components/ModuleInstallList.vue
+++ b/packages/devtools/client/components/ModuleInstallList.vue
@@ -16,7 +16,7 @@ const installedModules = useInstalledModules()
 const sortingOptions = ['downloads', 'stars', 'updated', 'created'] as const
 const ascendingOrder = ref(false)
 const selectedSortingOption = ref<typeof sortingOptions[number]>(sortingOptions[0])
-const installedFilter = ref(false)
+const excludeInstalled = ref(true)
 
 const sortingFactors: Record<typeof sortingOptions[number], SortingFunction<ModuleStaticInfo>> = {
   downloads: (a, b) => a.stats.downloads - b.stats.downloads,
@@ -48,7 +48,7 @@ const fuse = computed(() => new Fuse(collection.value || [], {
 
 const items = computed(() => {
   let filteredItems = sortedItems.value
-  if (installedFilter.value) {
+  if (excludeInstalled.value) {
     filteredItems = (filteredItems || []).filter(item => !installedModules.value.some(installed => installed.name === item.name))
   }
   if (!search.value)
@@ -102,12 +102,14 @@ const items = computed(() => {
           </div>
         </NDropdown>
       </template>
-      <NCheckbox v-model="installedFilter" n="primary md">
-        <span op75>Hide installed modules</span>
-      </NCheckbox>
-      <div flex="~ gap1" text-sm op50>
-        <span v-if="search || installedFilter">{{ items?.length }} matched · </span>
-        <span>{{ collection?.length }} modules in total</span>
+      <div flex="~ items-center gap-2">
+        <NCheckbox v-model="excludeInstalled" n="primary md">
+          <span op75>Exclude installed modules</span>
+        </NCheckbox>
+        <div flex="~ gap1" text-sm op50>
+          <span v-if="search || excludeInstalled">{{ items?.length }} matched · </span>
+          <span>{{ collection?.length }} modules in total</span>
+        </div>
       </div>
     </NNavbar>
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #780

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

#### 🆒 Your use case
I am doing interface development in Vue3. While the currently used libraries are visible in the Modules tab, I finally wondered about the "Install New Module" button. When I clicked it, I saw that all the libraries were listed.

However, I noticed that the libraries I am currently using were included in the list without being filtered. For this reason, I thought a filtered list would be nice.

#### 🆕 The solution you'd like
The libraries in the "Install New Module" list can be filtered from those I currently use, or the list can be made cleaner with an option such as "Filter those I currently use".

| Filter Off | Filter On |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/d93c07a9-fd56-4f72-b982-44ab34eed996) | ![Image](https://github.com/user-attachments/assets/13e9f440-b36d-452f-8ceb-656caf0ca3b9) | 
