### PR TITLE
build: only apply build output customisation to client build

### DIFF
--- a/packages/devtools/client/nuxt.config.ts
+++ b/packages/devtools/client/nuxt.config.ts
@@ -96,25 +96,27 @@ export default defineNuxtConfig({
 
   vite: {
     warmupEntry: false,
-    build: {
-      target: 'esnext',
-      rollupOptions: {
-        output: {
-          chunkFileNames(chunkInfo) {
-            const kebabName = chunkInfo.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-            return `_nuxt/${kebabName}-[hash].js`
+    $client: {
+      build: {
+        target: 'esnext',
+        rollupOptions: {
+          output: {
+            chunkFileNames(chunkInfo) {
+              const kebabName = chunkInfo.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+              return `_nuxt/${kebabName}-[hash].js`
+            },
+            assetFileNames(assetInfo) {
+              const kebabName = (assetInfo.name || '').replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+              return `_nuxt/${kebabName}-[hash][extname]`
+            },
+            manualChunks(id) {
+              for (const bundle of Object.entries(packageBundles)) {
+                if (bundle[1].some(pkg => id.includes(`node_modules/${pkg}/`)))
+                  return `vendor/${bundle[0]}`
+              }
+            },
+            hashCharacters: 'base36',
           },
-          assetFileNames(assetInfo) {
-            const kebabName = (assetInfo.name || '').replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
-            return `_nuxt/${kebabName}-[hash][extname]`
-          },
-          manualChunks(id) {
-            for (const bundle of Object.entries(packageBundles)) {
-              if (bundle[1].some(pkg => id.includes(`node_modules/${pkg}/`)))
-                return `vendor/${bundle[0]}`
-            }
-          },
-          hashCharacters: 'base36',
         },
       },
     },


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt has switched to use `preserveModules` for Vite server build, meaning that manual chunks won't work.

I will likely revert this for this reason but it's probably safer only to customise the vite _client_ chunks.