### PR TITLE
fix: watch() typeof check on array is always false

### DIFF
--- a/packages/devtools/client/components/StateEditor.vue
+++ b/packages/devtools/client/components/StateEditor.vue
@@ -43,9 +43,9 @@ onMounted(() => {
 
   watch(
     () => [props.revision, props.state],
-    (value) => {
-      if (typeof value !== 'number' && typeof value !== 'string')
-        deepSync(value, props.state)
+    ([_, state]) => {
+      if (typeof state !== 'number' && typeof state !== 'string')
+        deepSync(state, props.state)
       else
         proxy.value = props.state
     },
@@ -54,15 +54,13 @@ onMounted(() => {
 })
 
 function deepSync(from: any, to: any) {
-  // const fromRevision = from[0]
-  const fromValue = from[1]
-  for (const key in fromValue) {
-    if (Array.isArray(fromValue[key]))
-      to[key] = fromValue[key].slice()
-    else if (typeof fromValue[key] === 'object' && fromValue[key] !== null)
-      deepSync(fromValue[key], to[key])
+  for (const key in from) {
+    if (Array.isArray(from[key]))
+      to[key] = from[key].slice()
+    else if (typeof from[key] === 'object' && from[key] !== null)
+      deepSync(from[key], to[key])
     else
-      to[key] = fromValue[key]
+      to[key] = from[key]
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #849, resolves #768


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Destructured the watched values in the callback and applied the typeof check directly on state. Now:

- If state is an object (non-null), it calls deepSync.
- If state is a primitive, it assigns proxy.value directly.

The watch callback was checking the typeof the entire array [props.revision, props.state], which always returns "object", causing it to always enter the deepSync branch — even when props.state is a primitive (e.g., string, number).

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
