### PR TITLE
fix(ui-kit): add `@unocss-include` magic string in NButton

### DIFF
--- a/packages/devtools-ui-kit/src/components/NButton.ts
+++ b/packages/devtools-ui-kit/src/components/NButton.ts
@@ -4,7 +4,7 @@ import { defineComponent, h, renderSlot } from 'vue'
 import NIcon from './NIcon.vue'
 
 // eslint-disable-next-line ts/no-unused-expressions
-'@unocss-include' // this is a hack to include unocss styles in the build
+'@unocss-include' // this is a trick to keep @unocss-include in the built file. esbuild treeshakes comments
 export default defineComponent({
   name: 'NButton',
   props: {

--- a/packages/devtools-ui-kit/src/components/NButton.ts
+++ b/packages/devtools-ui-kit/src/components/NButton.ts
@@ -3,7 +3,8 @@ import { NuxtLink } from '#components'
 import { defineComponent, h, renderSlot } from 'vue'
 import NIcon from './NIcon.vue'
 
-// @unocss-include
+// eslint-disable-next-line ts/no-unused-expressions
+'@unocss-include' // this is a hack to include unocss styles in the build
 export default defineComponent({
   name: 'NButton',
   props: {


### PR DESCRIPTION
### 🔗 Linked issue

fix #851 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

This PR moves `@unocss-include` into a string instead of a comment so esbuild would preserve it postbuild. 
And I feel ashamed of this workaround.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
