### PR TITLE
feat(devtools,devtools-kit): expose vue-tracer state in inspector

### DIFF
--- a/packages/devtools-kit/src/_types/client-api.ts
+++ b/packages/devtools-kit/src/_types/client-api.ts
@@ -5,6 +5,7 @@ import type { NuxtApp } from 'nuxt/app'
 import type { AppConfig } from 'nuxt/schema'
 import type { $Fetch } from 'ofetch'
 import type { BuiltinLanguage } from 'shiki'
+import type { state } from 'vite-plugin-vue-tracer/client/overlay'
 import type { Ref } from 'vue'
 import type { HookInfo, LoadingTimeMetric, PluginMetric } from './integrations'
 import type { ClientFunctions, ServerFunctions } from './rpc'
@@ -64,6 +65,7 @@ export interface NuxtDevtoolsHostClient {
     toggle: () => void
     isEnabled: Ref<boolean>
     isAvailable: Ref<boolean>
+    state: typeof state
   }
 
   devtools: {

--- a/packages/devtools/src/runtime/plugins/view/client.ts
+++ b/packages/devtools/src/runtime/plugins/view/client.ts
@@ -221,6 +221,7 @@ export async function setupDevToolsClient({
       toggle: () => {
         inspectorState.isEnabled = !inspectorState.isEnabled
       },
+      state: inspectorState,
     })
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

This PR exposes the state from vue-tracer. It's more convenient if module integrations wants to use the overlay without triggering any hooks from devtools. Instead of creating the plugin in the main nuxt app then having the devtools retrieving the state from `client.value?.host.nuxt` .


<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
