### PR TITLE
fix(ui-kit): use object syntax for NButton slots

### DIFF
--- a/packages/devtools-ui-kit/src/components/NButton.ts
+++ b/packages/devtools-ui-kit/src/components/NButton.ts
@@ -33,16 +33,18 @@ export default defineComponent({
         slots.default ? '' : 'n-icon-button',
         'n-button n-transition n-disabled:n-disabled',
       ].join(' '),
-    }, [
-      renderSlot(slots, 'icon', {}, () => props.icon
-        ? [
-            h(NIcon, {
-              icon: props.icon,
-              class: slots.default ? 'n-button-icon' : '',
-            }),
-          ]
-        : []),
-      renderSlot(slots, 'default'),
-    ])
+    }, {
+      default: () => [
+        renderSlot(slots, 'icon', {}, () => props.icon
+          ? [
+              h(NIcon, {
+                icon: props.icon,
+                class: slots.default ? 'n-button-icon' : '',
+              }),
+            ]
+          : []),
+        renderSlot(slots, 'default'),
+      ],
+    })
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this PR moves the slots of `<NButton>` to object syntax to avoid having `Non-function value encountered for default slot. Prefer function slots for better performance. ` warning from Vue when using it with `to` props which renders a `<NuxtLink>`

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
