### PR TITLE
fix(devtools-kit): explicitly type return type of useDevtoolsHostClient

### DIFF
--- a/packages/devtools-kit/src/runtime/host-client.ts
+++ b/packages/devtools-kit/src/runtime/host-client.ts
@@ -35,7 +35,7 @@ export function onDevtoolsHostClientConnected(fn: (client: NuxtDevtoolsHostClien
   }
 }
 
-export function useDevtoolsHostClient() {
+export function useDevtoolsHostClient(): Ref<NuxtDevtoolsHostClient | undefined> {
   if (!clientRef) {
     clientRef = shallowRef<NuxtDevtoolsHostClient | undefined>()
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

TS or Rollup isn't able to detect the return type of `useDevtoolsHostClient` so we have to sstrongly type it

![image](https://github.com/user-attachments/assets/70701720-ead8-4c14-b24b-c03cb93b7798)



<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
