### PR TITLE
fix: timing labels should not wrap

### DIFF
--- a/packages/devtools/src/webcomponents/style.css
+++ b/packages/devtools/src/webcomponents/style.css
@@ -152,12 +152,14 @@
 
 #nuxt-devtools-anchor .nuxt-devtools-label .nuxt-devtools-label-main {
   opacity: 0.8;
+  white-space: nowrap;
 }
 
 #nuxt-devtools-anchor .nuxt-devtools-label .nuxt-devtools-label-secondary {
   font-size: 0.8em;
   line-height: 0.6em;
   opacity: 0.5;
+  white-space: nowrap;
 }
 
 #nuxt-devtools-anchor .nuxt-devtools-nuxt-button {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This is a small change to the CSS for the labels on the minimized devtools widget to make it so that the text does not wrap.

#### Before
<img width="183" alt="Screenshot 2025-06-07 at 4 10 30 PM" src="https://github.com/user-attachments/assets/af18f4bb-e23b-417e-99b6-62c6f88f4ca5" />

#### After
<img width="197" alt="Screenshot 2025-06-07 at 4 25 51 PM" src="https://github.com/user-attachments/assets/70f92940-f602-462b-b772-9e370f1616be" />

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
