### PR TITLE
feat: support passing additional permissions to the iframe

### DIFF
--- a/docs/content/2.module/0.guide.md
+++ b/docs/content/2.module/0.guide.md
@@ -59,6 +59,21 @@ nuxt.hook('devtools:customTabs', (tabs) => {
 })
 ```
 
+### Iframe Permissions
+
+By default, iframes have `clipboard-write` and `clipboard-read` permissions enabled. You can add additional permissions using the `permissions` option:
+
+```ts
+const view: ModuleIframeView = {
+  type: 'iframe',
+  src: '/url-to-your-module-view',
+  // Additional permissions to allow in the iframe
+  permissions: ['camera', 'microphone', 'geolocation'],
+}
+```
+
+These permissions will be merged with the default ones and set on the iframe's `allow` attribute.
+
 Learn more about [DevTools Utility Kit](/module/utils-kit).
 
 ## Lazy Service Launching

--- a/docs/content/2.module/1.utils-kit.md
+++ b/docs/content/2.module/1.utils-kit.md
@@ -39,6 +39,21 @@ addCustomTab(() => ({
 }))
 ```
 
+The iframe view supports the following options:
+
+- `src`: URL of the iframe
+- `persistent`: Whether to persist the iframe instance when switching tabs (default: `true`)
+- `permissions`: Additional permissions to allow in the iframe (merged with default `clipboard-write` and `clipboard-read`)
+
+```ts
+const view: ModuleIframeView = {
+  type: 'iframe',
+  src: '/url-to-your-module-view',
+  persistent: true,
+  permissions: ['camera', 'microphone'],
+}
+```
+
 ### `refreshCustomTabs()`
 
 A shorthand for call hook `devtools:customTabs:refresh`. It will refresh all custom tabs.

--- a/packages/devtools-kit/src/_types/custom-tabs.ts
+++ b/packages/devtools-kit/src/_types/custom-tabs.ts
@@ -68,6 +68,13 @@ export interface ModuleIframeView {
    * @default true
    */
   persistent?: boolean
+  /**
+   * Additional permissions to allow in the iframe
+   * These will be merged with the default permissions (clipboard-write, clipboard-read)
+   *
+   * @example ['camera', 'microphone', 'geolocation']
+   */
+  permissions?: string[]
 }
 
 export interface ModuleVNodeView {

--- a/packages/devtools/client/components/IframeView.vue
+++ b/packages/devtools/client/components/IframeView.vue
@@ -23,7 +23,7 @@ const box = reactive(useElementBounding(anchor))
 onMounted(() => {
   const view = props.tab.view as ModuleIframeView
   const isPersistent = view.persistent !== false
-  const allowedPermissions = ['clipboard-write', 'clipboard-read']
+  const allowedPermissions = ['clipboard-write', 'clipboard-read', ...(view.permissions || [])]
 
   if (iframeCacheMap.get(key.value) && isPersistent) {
     iframeEl.value = iframeCacheMap.get(key.value)!


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #214

related https://github.com/nuxt-hub/core/issues/684

### ❓ Type of change

Adds ability to pass additional permissions to the iframe when registering a custom tab. Previously they were hard coded in #215.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
