### PR TITLE
fix(devtools): call `devtools:initialized` hook after all modules run

### DIFF
--- a/packages/devtools/src/module-main.ts
+++ b/packages/devtools/src/module-main.ts
@@ -240,7 +240,7 @@ window.__NUXT_DEVTOOLS_TIME_METRIC__.appInit = Date.now()
 
   await Promise.all(integrations)
 
-  nuxt.hook('modules:done', async () => nuxt.callHook('devtools:initialized', {
+  nuxt.hook('modules:done', () => nuxt.callHook('devtools:initialized', {
     version,
     packagePath: packageDir,
     isGlobalInstall: isGlobalInstall(),


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/a11y/issues/216

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this moves the `devtools:initialized` hook to after all modules have a chance to run and register their callbacks