### PR TITLE
fix(devtools): resolve non-props attributes warning for NuxtDevtoolsInspectPanel

### DIFF
--- a/packages/devtools/src/webcomponents/components/NuxtDevtoolsInspectPanel.vue
+++ b/packages/devtools/src/webcomponents/components/NuxtDevtoolsInspectPanel.vue
@@ -3,6 +3,9 @@ import type { NuxtDevToolsInspectorProps } from './Props'
 import { onClickOutside, useDraggable } from '@vueuse/core'
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
 
+defineOptions({
+  inheritAttrs: false,
+})
 const { props } = defineProps<{ props: NuxtDevToolsInspectorProps }>()
 const emit = defineEmits<{
   (e: 'close'): void
@@ -227,6 +230,7 @@ async function copyAgentInfo() {
       isDragging ? 'transition-none' : 'transition-opacity',
       props.matched ? 'op100' : 'op0 pointer-events-none',
     ]"
+    v-bind="$attrs"
   >
     <!-- <div
       class="pointer-events-none absolute inset-0 z-10 transition-opacity duration-300"


### PR DESCRIPTION
### 🔗 Linked issue

resolves #929

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes the "Extraneous non-props attributes" warning in the NuxtDevtoolsInspectPanel component.

The warning was caused by the component having multiple root nodes, which prevented Vue from automatically deciding where to apply attributes.

Instead of restructuring the DOM, which could lead to CSS clipping or z-index issues for the toast notification, I implemented manual attribute binding.
<img width="2784" height="92" alt="20260213230216_2_202" src="https://github.com/user-attachments/assets/87aeb662-08a4-4179-a8f4-ec53758b41be" />


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
