### PR TITLE
fix(devtools): add zeditor option for Zed on Arch Linux

### DIFF
--- a/packages/devtools/client/pages/settings.vue
+++ b/packages/devtools/client/pages/settings.vue
@@ -36,6 +36,7 @@ const editorOptions = [
   ['VS Code Insider', 'vscode-insider'],
   ['Cursor', 'cursor'],
   ['Zed', 'zed'],
+  ['Zed (zeditor)', 'zeditor'],
   ['WebStorm', 'webstorm'],
   ['Sublime Text', 'sublime'],
   ['Atom', 'atom'],


### PR DESCRIPTION
## Summary
- add a `Zed (zeditor)` option in DevTools settings for environments where the Zed binary is exposed as `zeditor`
- keep the existing `Zed` (`zed`) option unchanged to avoid behavior changes on other platforms
- keep implementation simple by handling this as an explicit editor choice in settings

## Why this is needed
On some Linux distributions (notably Arch Linux), the Zed package exposes the executable as `zeditor` instead of `zed`.

Before this change, users selecting `Zed` in DevTools would fail to open files from "Open in editor" despite having Zed installed, because DevTools passed `zed` to `launch-editor`.

Adding an explicit `zeditor` option:
- fixes the workflow for Arch users,
- avoids platform-specific server-side fallback logic,
- preserves current behavior for everyone already using `zed`.