### PR TITLE
docs: add package resolution instructions for v4.0 opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,20 +44,99 @@ export default defineNuxtConfig({
 })
 ```
 
+### Opting in to v4.0
+
+Nuxt DevTools v4.0 is currently in alpha. Since Nuxt ships with a built-in version of DevTools, you can opt-in to v4.0 by using package manager resolutions to override the bundled version:
+
+<details>
+<summary>npm</summary>
+
+```json
+{
+  "overrides": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>yarn</summary>
+
+```json
+{
+  "resolutions": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>pnpm</summary>
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+    }
+  }
+}
+```
+
+</details>
+
+Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall dependencies.
+
 ### Nightly Release Channel
 
 Similar to [Nuxt's Nightly Channel](https://nuxt.com/docs/guide/going-further/nightly-release-channel), DevTools also offers a nightly release channel, that automatically releases for every commit to `main` branch.
 
-You can opt-in to the nightly release channel by running:
+You can opt-in to the nightly release channel by using package manager resolutions:
 
-```diff
+<details>
+<summary>npm</summary>
+
+```json
 {
-  "devDependencies": {
---    "@nuxt/devtools": "^0.1.0"
-++    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  "overrides": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
   }
 }
 ```
+
+</details>
+
+<details>
+<summary>yarn</summary>
+
+```json
+{
+  "resolutions": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>pnpm</summary>
+
+```json
+{
+  "pnpm": {
+    "overrides": {
+      "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+    }
+  }
+}
+```
+
+</details>
 
 Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall dependencies.
 

--- a/docs/content/1.guide/0.getting-started.md
+++ b/docs/content/1.guide/0.getting-started.md
@@ -17,20 +17,77 @@ export default defineNuxtConfig({
 
 Restart your Nuxt server and open your app in browser. Click the Nuxt icon on the bottom (or press :kbd{value="Shift"} + :kbd{value="Alt"} / :kbd{value="⇧ Shift"} + :kbd{value="⌥ Option"} + :kbd{value="D"}) to toggle the DevTools.
 
+### Opting in to v4.0
+
+Nuxt DevTools v4.0 is currently in alpha. Since Nuxt ships with a built-in version of DevTools, you can opt-in to v4.0 by using package manager resolutions to override the bundled version:
+
+::code-group
+
+```json [npm]
+{
+  "overrides": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  }
+}
+```
+
+```json [yarn]
+{
+  "resolutions": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  }
+}
+```
+
+```json [pnpm]
+{
+  "pnpm": {
+    "overrides": {
+      "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+    }
+  }
+}
+```
+
+::
+
+Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall dependencies.
+
 ### Nightly Release Channel
 
 Similar to [Nuxt's Nightly Channel](https://nuxt.com/docs/guide/going-further/nightly-release-channel), DevTools also offers a nightly release channel, that automatically releases for every commit to `main` branch.
 
-You can opt-in to the nightly release channel by running:
+You can opt-in to the nightly release channel by using package manager resolutions:
 
-```diff
+::code-group
+
+```json [npm]
 {
-  "devDependencies": {
---    "@nuxt/devtools": "^0.1.0"
-++    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  "overrides": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
   }
 }
 ```
+
+```json [yarn]
+{
+  "resolutions": {
+    "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+  }
+}
+```
+
+```json [pnpm]
+{
+  "pnpm": {
+    "overrides": {
+      "@nuxt/devtools": "npm:@nuxt/devtools-nightly@latest"
+    }
+  }
+}
+```
+
+::
 
 Remove lockfile (`package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`) and reinstall dependencies.
 


### PR DESCRIPTION
## Summary

- Added comprehensive "Opting in to v4.0" section with package manager-specific instructions (npm, yarn, pnpm) for overriding the bundled DevTools with the v4 alpha version
- Updated the "Nightly Release Channel" section to use the same resolution-based approach for consistency across all package managers

This clarifies how users can opt into the v4 alpha by using package manager resolutions/overrides instead of modifying devDependencies directly.