### PR TITLE
fix(devtools-kit): pass cwd to execa

### DIFF
--- a/packages/devtools-kit/src/index.ts
+++ b/packages/devtools-kit/src/index.ts
@@ -50,7 +50,7 @@ export function startSubprocess(
       {
         nodeOptions: {
           ...execaOptions.nodeOptions,
-          cwd: execaOptions.cwd,
+          cwd: execaOptions.cwd ?? execaOptions.nodeOptions?.cwd,
           env: {
             ...process.env,
             COLORS: 'true',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Ran into some issues when starting devtools in local mode. 
Seems like execa gets cwd from nodeOptions now 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
