### PR TITLE
fix: persist async data across tab navigation

### DIFF
--- a/packages/devtools/client/composables/utils.ts
+++ b/packages/devtools/client/composables/utils.ts
@@ -80,12 +80,14 @@ export function parseReadablePath(path: string, root: string) {
 
 export function useAsyncState<T>(key: string, fn: () => Promise<T>, options?: AsyncDataOptions<T>) {
   const nuxt = useNuxtApp()
-
-  const unique = nuxt.payload.unique = nuxt.payload.unique || {} as any
-  if (!unique[key])
-    unique[key] = useAsyncData(key, fn, options)
-
-  return unique[key].data as Ref<T | null>
+  const { data } = useAsyncData(key, fn, {
+    ...options,
+    // Custom getCachedData serves two purposes:
+    // 1. Returns previously fetched data from payload.data on remount, so pages render instantly
+    // 2. Prevents Nuxt's purgeCachedData from clearing data when the last consumer unmounts
+    getCachedData: key => nuxt.payload.data[key] as T,
+  })
+  return data as Ref<T | null>
 }
 
 export function getIsMacOS() {


### PR DESCRIPTION
## Summary

The imports tab (and other tabs) would show empty after navigating away and back because Nuxt's `purgeCachedData` cleared the cached data on unmount. When remounting, the default `getCachedData` only checks `nuxtApp.static.data` (empty in SPA mode), not `payload.data` where the actual fetch result is stored.

## Solution

Provide a custom `getCachedData` that reads from `payload.data[key]`. This both:
- Prevents `clearNuxtDataByKey` from running when the last consumer unmounts (line 459 of asyncData.js)
- Returns previously fetched data on remount, so pages render instantly with cached data instead of showing blank

## Testing

The imports, components, and pages tabs should now persist data correctly across navigation without showing empty states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)