### PR TITLE
feat!: remove deprecated auth token args from builtin RPC functions

### DIFF
--- a/packages/devtools-kit/src/_types/rpc.ts
+++ b/packages/devtools-kit/src/_types/rpc.ts
@@ -13,7 +13,7 @@ export interface ServerFunctions {
   // Static RPCs (can be provide on production build in the future)
   getServerConfig: () => NuxtOptions
   getServerDebugContext: () => Promise<ServerDebugContext | undefined>
-  getServerData: (token: string) => Promise<NuxtServerData>
+  getServerData: () => Promise<NuxtServerData>
   getServerRuntimeConfig: () => Record<string, any>
   getModuleOptions: () => ModuleOptions
   getComponents: () => Component[]
@@ -36,46 +36,46 @@ export interface ServerFunctions {
   // Updates
   checkForUpdateFor: (name: string) => Promise<PackageUpdateInfo | undefined>
   getNpmCommand: (command: NpmCommandType, packageName: string, options?: NpmCommandOptions) => Promise<string[] | undefined>
-  runNpmCommand: (token: string, command: NpmCommandType, packageName: string, options?: NpmCommandOptions) => Promise<{ processId: string } | undefined>
+  runNpmCommand: (command: NpmCommandType, packageName: string, options?: NpmCommandOptions) => Promise<{ processId: string } | undefined>
 
   // Terminal
   getTerminals: () => TerminalInfo[]
-  getTerminalDetail: (token: string, id: string) => Promise<TerminalInfo | undefined>
-  runTerminalAction: (token: string, id: string, action: TerminalAction) => Promise<boolean>
+  getTerminalDetail: (id: string) => Promise<TerminalInfo | undefined>
+  runTerminalAction: (id: string, action: TerminalAction) => Promise<boolean>
 
   // Storage
   getStorageMounts: () => Promise<StorageMounts>
   getStorageKeys: (base?: string) => Promise<string[]>
-  getStorageItem: (token: string, key: string) => Promise<StorageValue>
-  setStorageItem: (token: string, key: string, value: StorageValue) => Promise<void>
-  removeStorageItem: (token: string, key: string) => Promise<void>
+  getStorageItem: (key: string) => Promise<StorageValue>
+  setStorageItem: (key: string, value: StorageValue) => Promise<void>
+  removeStorageItem: (key: string) => Promise<void>
 
   // Analyze
   getAnalyzeBuildInfo: () => Promise<AnalyzeBuildsInfo>
   generateAnalyzeBuildName: () => Promise<string>
-  startAnalyzeBuild: (token: string, name: string) => Promise<string>
-  clearAnalyzeBuilds: (token: string, names?: string[]) => Promise<void>
+  startAnalyzeBuild: (name: string) => Promise<string>
+  clearAnalyzeBuilds: (names?: string[]) => Promise<void>
 
   // Queries
-  getImageMeta: (token: string, filepath: string) => Promise<ImageMeta | undefined>
-  getTextAssetContent: (token: string, filepath: string, limit?: number) => Promise<string | undefined>
-  writeStaticAssets: (token: string, file: AssetEntry[], folder: string) => Promise<string[]>
-  deleteStaticAsset: (token: string, filepath: string) => Promise<void>
-  renameStaticAsset: (token: string, oldPath: string, newPath: string) => Promise<void>
+  getImageMeta: (filepath: string) => Promise<ImageMeta | undefined>
+  getTextAssetContent: (filepath: string, limit?: number) => Promise<string | undefined>
+  writeStaticAssets: (file: AssetEntry[], folder: string) => Promise<string[]>
+  deleteStaticAsset: (filepath: string) => Promise<void>
+  renameStaticAsset: (oldPath: string, newPath: string) => Promise<void>
 
   // Actions
   telemetryEvent: (payload: object, immediate?: boolean) => void
   customTabAction: (name: string, action: number) => Promise<boolean>
-  enablePages: (token: string) => Promise<void>
+  enablePages: () => Promise<void>
   openInEditor: (filepath: string) => Promise<boolean>
-  restartNuxt: (token: string, hard?: boolean) => Promise<void>
-  installNuxtModule: (token: string, name: string, dry?: boolean) => Promise<InstallModuleReturn>
-  uninstallNuxtModule: (token: string, name: string, dry?: boolean) => Promise<InstallModuleReturn>
+  restartNuxt: (hard?: boolean) => Promise<void>
+  installNuxtModule: (name: string, dry?: boolean) => Promise<InstallModuleReturn>
+  uninstallNuxtModule: (name: string, dry?: boolean) => Promise<InstallModuleReturn>
   enableTimeline: (dry: boolean) => Promise<[string, string]>
 
   // Dev Token
   requestForAuth: (info?: string, origin?: string) => Promise<void>
-  verifyAuthToken: (token: string) => Promise<boolean>
+  verifyAuthToken: () => Promise<boolean>
 }
 
 export interface ClientFunctions {

--- a/packages/devtools-kit/src/_types/server-ctx.ts
+++ b/packages/devtools-kit/src/_types/server-ctx.ts
@@ -41,11 +41,6 @@ export interface NuxtDevtoolsServerContext {
    */
   refresh: (event: keyof ServerFunctions) => void
 
-  /**
-   * @deprecated Auth is now handled by Vite DevTools. This is a noop.
-   */
-  ensureDevAuthToken: (token: string) => Promise<void>
-
   extendServerRpc: <ClientFunctions extends object = Record<string, unknown>, ServerFunctions extends object = Record<string, unknown>>(name: string, functions: ServerFunctions) => BirpcGroup<ClientFunctions, ServerFunctions>
 }
 

--- a/packages/devtools/client/app.vue
+++ b/packages/devtools/client/app.vue
@@ -77,7 +77,7 @@ onMounted(async () => {
 
   if (!isDevAuthed.value) {
     if (devAuthToken.value) {
-      const result = await rpc.verifyAuthToken(devAuthToken.value)
+      const result = await rpc.verifyAuthToken()
       if (result)
         isDevAuthed.value = true
     }

--- a/packages/devtools/client/components/AssetDetails.vue
+++ b/packages/devtools/client/components/AssetDetails.vue
@@ -3,7 +3,6 @@ import type { AssetInfo, CodeSnippet } from '~/../src/types'
 import { devtoolsUiShowNotification } from '#imports'
 import { computedAsync, useTimeAgo, useVModel } from '@vueuse/core'
 import { computed, ref } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { useCopy, useOpenInEditor } from '~/composables/editor'
 import { rpc } from '~/composables/rpc'
 import { useServerConfig } from '~/composables/state'
@@ -18,7 +17,7 @@ const asset = useVModel(props, 'modelValue', emit, { passive: true })
 const imageMeta = computedAsync(async () => {
   if (asset.value.type !== 'image')
     return undefined
-  return rpc.getImageMeta(await ensureDevAuthToken(), asset.value.filePath)
+  return rpc.getImageMeta(asset.value.filePath)
 })
 
 const editDialog = ref(false)
@@ -31,7 +30,7 @@ const textContent = computedAsync(async () => {
   // eslint-disable-next-line ts/no-unused-expressions
   textContentCounter.value
 
-  const content = await rpc.getTextAssetContent(await ensureDevAuthToken(), asset.value.filePath)
+  const content = await rpc.getTextAssetContent(asset.value.filePath)
   newTextContent.value = content
   return content
 })
@@ -39,7 +38,7 @@ const textContent = computedAsync(async () => {
 async function saveTextContent() {
   if (textContent.value !== newTextContent.value) {
     try {
-      await rpc.writeStaticAssets(await ensureDevAuthToken(), [{
+      await rpc.writeStaticAssets([{
         path: asset.value.path,
         content: newTextContent.value,
         override: true,
@@ -134,7 +133,7 @@ const supportsPreview = computed(() => {
 const deleteDialog = ref(false)
 async function deleteAsset() {
   try {
-    await rpc.deleteStaticAsset(await ensureDevAuthToken(), asset.value.filePath)
+    await rpc.deleteStaticAsset(asset.value.filePath)
     asset.value = undefined as any
     deleteDialog.value = false
     devtoolsUiShowNotification({
@@ -170,7 +169,7 @@ async function renameAsset() {
   try {
     const extension = parts.slice(-1)[0]?.split('.').slice(-1)[0]
     const fullPath = `${parts.slice(0, -1).join('/')}/${newName.value}.${extension}`
-    await rpc.renameStaticAsset(await ensureDevAuthToken(), asset.value.filePath, fullPath)
+    await rpc.renameStaticAsset(asset.value.filePath, fullPath)
     asset.value = undefined as any
     renameDialog.value = false
     devtoolsUiShowNotification({

--- a/packages/devtools/client/components/AssetDropZone.vue
+++ b/packages/devtools/client/components/AssetDropZone.vue
@@ -3,7 +3,6 @@ import type { AssetEntry } from '~/../src/types'
 import { devtoolsUiShowNotification } from '#imports'
 import { useEventListener, useVModel } from '@vueuse/core'
 import { ref } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { rpc, wsConnecting, wsError } from '~/composables/rpc'
 import { telemetry } from '~/composables/telemetry'
 
@@ -95,7 +94,7 @@ async function uploadFiles() {
       content,
     })
   }
-  await rpc.writeStaticAssets(await ensureDevAuthToken(), [...uploadFiles], props.folder).then(() => {
+  await rpc.writeStaticAssets([...uploadFiles], props.folder).then(() => {
     close()
     devtoolsUiShowNotification({
       message: 'Files uploaded successfully!',

--- a/packages/devtools/client/components/BuildAnalyzeDetails.vue
+++ b/packages/devtools/client/components/BuildAnalyzeDetails.vue
@@ -3,7 +3,6 @@ import type { AnalyzeBuildMeta } from '../../src/types'
 import { useRuntimeConfig } from '#imports'
 import { formatTimeAgo } from '@vueuse/core'
 import { computed, ref } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { rpc } from '~/composables/rpc'
 
 const props = defineProps<{
@@ -46,7 +45,7 @@ function formatFileSize(bytes: number) {
 }
 
 async function clear(name: string) {
-  return rpc.clearAnalyzeBuilds(await ensureDevAuthToken(), [name])
+  return rpc.clearAnalyzeBuilds([name])
 }
 </script>
 

--- a/packages/devtools/client/components/ModuleItemInstall.vue
+++ b/packages/devtools/client/components/ModuleItemInstall.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { ModuleActionType, ModuleStaticInfo } from '../../src/types'
 import { computed } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { ModuleDialog } from '~/composables/dialog'
 import { rpc } from '~/composables/rpc'
 import { useInstalledModules } from '~/composables/state-modules'
@@ -21,7 +20,7 @@ const isUninstallable = computed(() => installedInfo.value && installedInfo.valu
 
 async function useModuleAction(item: ModuleStaticInfo, type: ModuleActionType) {
   const method = type === 'install' ? rpc.installNuxtModule : rpc.uninstallNuxtModule
-  const result = await method(await ensureDevAuthToken(), item.npm, true)
+  const result = await method(item.npm, true)
 
   telemetry(`modules:${type}`, {
     moduleName: item.npm,
@@ -41,7 +40,7 @@ async function useModuleAction(item: ModuleStaticInfo, type: ModuleActionType) {
 
   emit('start')
 
-  await method(await ensureDevAuthToken(), item.npm, false)
+  await method(item.npm, false)
 }
 
 const anyObj = {} as any

--- a/packages/devtools/client/components/RestartDialogs.vue
+++ b/packages/devtools/client/components/RestartDialogs.vue
@@ -2,7 +2,6 @@
 import { useNuxtApp } from '#app/nuxt'
 import { createTemplatePromise } from '@vueuse/core'
 import { useClient } from '~/composables/client'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { useRestartDialogs } from '~/composables/dialog'
 import { rpc } from '~/composables/rpc'
 
@@ -22,7 +21,7 @@ nuxt.hook('devtools:terminal:exit', ({ id, code }) => {
         .start(dialog.message)
         .then(async (result) => {
           if (result) {
-            rpc.restartNuxt(await ensureDevAuthToken())
+            rpc.restartNuxt()
             setTimeout(() => {
               client.value?.app.reload()
             }, 500)

--- a/packages/devtools/client/components/StorageDetails.vue
+++ b/packages/devtools/client/components/StorageDetails.vue
@@ -8,7 +8,6 @@ import { computed, onUnmounted, ref, watch, watchEffect } from 'vue'
 import { getColorMode } from '~/composables/client'
 import { rpc } from '~/composables/rpc'
 import { useSessionState } from '~/composables/utils'
-import { ensureDevAuthToken } from '../composables/dev-auth'
 
 const colorMode = getColorMode()
 const nuxtApp = useNuxtApp()
@@ -71,7 +70,7 @@ const filteredKeys = computed(() => {
 })
 
 async function fetchItem(key: string) {
-  const content = await rpc.getStorageItem(await ensureDevAuthToken(), key)
+  const content = await rpc.getStorageItem(key)
   currentItem.value = {
     key,
     updatedKey: keyName(key),
@@ -87,7 +86,7 @@ async function saveNewItem() {
   // If does not exists
   const key = `${currentStorage.value}:${newKey.value}`
   if (!storageKeys.value?.includes(key))
-    await rpc.setStorageItem(await ensureDevAuthToken(), key, '')
+    await rpc.setStorageItem(key, '')
 
   router.replace({ query: { storage: currentStorage.value, key } })
   newKey.value = ''
@@ -96,14 +95,14 @@ async function saveNewItem() {
 async function saveCurrentItem() {
   if (!currentItem.value)
     return
-  await rpc.setStorageItem(await ensureDevAuthToken(), currentItem.value.key, currentItem.value.updatedContent)
+  await rpc.setStorageItem(currentItem.value.key, currentItem.value.updatedContent)
   await fetchItem(currentItem.value.key)
 }
 
 async function removeCurrentItem() {
   if (!currentItem.value || !currentStorage.value)
     return
-  await rpc.removeStorageItem(await ensureDevAuthToken(), currentItem.value.key)
+  await rpc.removeStorageItem(currentItem.value.key)
   currentItem.value = null
 }
 
@@ -111,9 +110,8 @@ async function renameCurrentItem() {
   if (!currentItem.value || !currentStorage.value)
     return
   const renamedKey = `${currentStorage.value}:${currentItem.value.updatedKey}`
-  const token = await ensureDevAuthToken()
-  await rpc.setStorageItem(token, renamedKey, currentItem.value.updatedContent)
-  await rpc.removeStorageItem(token, currentItem.value.key)
+  await rpc.setStorageItem(renamedKey, currentItem.value.updatedContent)
+  await rpc.removeStorageItem(currentItem.value.key)
   router.replace({ query: { storage: currentStorage.value, key: renamedKey } })
 }
 </script>

--- a/packages/devtools/client/components/TerminalPage.vue
+++ b/packages/devtools/client/components/TerminalPage.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, watchEffect } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { rpc } from '~/composables/rpc'
 import { useTerminals } from '~/composables/state'
 import { useCurrentTerminalId } from '~/composables/state-routes'
@@ -9,8 +8,8 @@ const terminals = useTerminals()
 const terminalId = useCurrentTerminalId()
 const selected = computed(() => terminals.value?.find(t => t.id === terminalId.value))
 
-async function remove(id: string) {
-  rpc.runTerminalAction(await ensureDevAuthToken(), id, 'remove')
+function remove(id: string) {
+  rpc.runTerminalAction(id, 'remove')
 }
 
 watchEffect(() => {

--- a/packages/devtools/client/components/TerminalView.vue
+++ b/packages/devtools/client/components/TerminalView.vue
@@ -5,7 +5,6 @@ import { useEventListener } from '@vueuse/core'
 import { FitAddon } from '@xterm/addon-fit'
 import { Terminal } from '@xterm/xterm'
 import { onMounted, ref } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { rpc } from '~/composables/rpc'
 import '@xterm/xterm/css/xterm.css'
 
@@ -33,7 +32,7 @@ onMounted(async () => {
     fitAddon.fit()
   })
 
-  info.value = await rpc.getTerminalDetail(await ensureDevAuthToken(), props.id)
+  info.value = await rpc.getTerminalDetail(props.id)
   if (info.value?.buffer)
     term.write(info.value.buffer)
 
@@ -44,17 +43,17 @@ onMounted(async () => {
   })
 })
 
-async function clear() {
-  rpc.runTerminalAction(await ensureDevAuthToken(), props.id, 'clear')
+function clear() {
+  rpc.runTerminalAction(props.id, 'clear')
   term?.clear()
 }
 
-async function restart() {
-  rpc.runTerminalAction(await ensureDevAuthToken(), props.id, 'restart')
+function restart() {
+  rpc.runTerminalAction(props.id, 'restart')
 }
 
-async function terminate() {
-  rpc.runTerminalAction(await ensureDevAuthToken(), props.id, 'terminate')
+function terminate() {
+  rpc.runTerminalAction(props.id, 'terminate')
 }
 </script>
 

--- a/packages/devtools/client/composables/dev-auth.ts
+++ b/packages/devtools/client/composables/dev-auth.ts
@@ -12,12 +12,6 @@ export function updateDevAuthToken(_token: string) {
   console.warn('[nuxt-devtools] `updateDevAuthToken` is deprecated. Auth is now handled by Vite DevTools.')
 }
 
-/** @deprecated Auth is now handled by Vite DevTools */
-export async function ensureDevAuthToken() {
-  console.warn('[nuxt-devtools] `ensureDevAuthToken` is deprecated. Auth is now handled by Vite DevTools.')
-  return ''
-}
-
 export const userAgentInfo = parseUA(navigator.userAgent)
 
 /** @deprecated Auth is now handled by Vite DevTools */

--- a/packages/devtools/client/composables/npm.ts
+++ b/packages/devtools/client/composables/npm.ts
@@ -2,7 +2,6 @@ import type { NpmCommandOptions } from '../../src/types'
 import { useNuxtApp } from '#app/nuxt'
 import semver from 'semver'
 import { computed, ref } from 'vue'
-import { ensureDevAuthToken } from './dev-auth'
 import { rpc } from './rpc'
 import { useAsyncState } from './utils'
 
@@ -58,7 +57,7 @@ function getPackageUpdate(name: string, options?: NpmCommandOptions) {
 
     state.value = 'running'
 
-    processId.value = (await rpc.runNpmCommand(await ensureDevAuthToken(), 'update', name, options))?.processId
+    processId.value = (await rpc.runNpmCommand('update', name, options))?.processId
 
     return processId.value
   }
@@ -66,7 +65,7 @@ function getPackageUpdate(name: string, options?: NpmCommandOptions) {
   async function restart() {
     if (state.value !== 'updated')
       return
-    await rpc.restartNuxt(await ensureDevAuthToken())
+    await rpc.restartNuxt()
   }
 
   return {

--- a/packages/devtools/client/pages/modules/analyze-build.vue
+++ b/packages/devtools/client/pages/modules/analyze-build.vue
@@ -4,7 +4,6 @@ import { useRouter } from '#app/composables/router'
 import { definePageMeta } from '#imports'
 import { createTemplatePromise, formatTimeAgo } from '@vueuse/core'
 import { computed, ref } from 'vue'
-import { ensureDevAuthToken } from '~/composables/dev-auth'
 import { satisfyNuxtVersion } from '~/composables/npm'
 import { rpc } from '~/composables/rpc'
 import { useAnalyzeBuildInfo } from '~/composables/state'
@@ -46,7 +45,7 @@ async function start() {
 
   processAnalyzeBuildInfo.value = {
     name: buildNameInput.value,
-    processId: await rpc.startAnalyzeBuild(await ensureDevAuthToken(), buildNameInput.value),
+    processId: await rpc.startAnalyzeBuild(buildNameInput.value),
   }
   if (shouldGotoTerminal.value)
     gotoTerminal()

--- a/packages/devtools/client/pages/modules/overview.vue
+++ b/packages/devtools/client/pages/modules/overview.vue
@@ -11,7 +11,6 @@ import { isFirstVisit } from '~/composables/storage'
 import { getIsMacOS } from '~/composables/utils'
 import { version } from '../../../package.json'
 import { showConnectionWarning } from '../../composables/client'
-import { ensureDevAuthToken } from '../../composables/dev-auth'
 import { formatDuration, pluralizeByCount } from '../../composables/utils'
 
 definePageMeta({
@@ -38,7 +37,7 @@ const vueVersion = computed(() => client.value?.nuxt.vueApp.version)
 const metricsLoading = computed(() => client.value?.metrics.loading())
 
 function authorize() {
-  ensureDevAuthToken()
+  // Auth is now handled by Vite DevTools
 }
 </script>
 

--- a/packages/devtools/client/pages/modules/pages.vue
+++ b/packages/devtools/client/pages/modules/pages.vue
@@ -181,7 +181,7 @@ const pagesPath = computed(() => `./${compatibilityVersion === 4 ? 'app/' : ''}p
       {
         label: 'Enable Routing',
         async handle() {
-          return rpc.enablePages(await ensureDevAuthToken())
+          return rpc.enablePages()
         },
       },
     ]"

--- a/packages/devtools/client/pages/modules/server-discovery.vue
+++ b/packages/devtools/client/pages/modules/server-discovery.vue
@@ -3,7 +3,6 @@ import { useRuntimeConfig } from '#app/nuxt'
 import { definePageMeta } from '#imports'
 import { connectToEmbedApp } from '@discoveryjs/discovery/dist/discovery-embed-host.js'
 import { onMounted, onUnmounted, useTemplateRef } from 'vue'
-import { ensureDevAuthToken } from '../../composables/dev-auth'
 import { rpc } from '../../composables/rpc'
 import { jsonStringifyCircular } from '../../composables/utils'
 
@@ -23,7 +22,7 @@ const iframe = useTemplateRef<HTMLIFrameElement>('iframe')
 onMounted(() => {
   const disconnect = connectToEmbedApp(iframe.value!, (app) => {
     (async () => {
-      const data = await rpc.getServerData(await ensureDevAuthToken())
+      const data = await rpc.getServerData()
       const json = `{${Object.entries(data).map(([key, value]) => `"${key}": ${jsonStringifyCircular(value)}`).join(',')}}`
       // @ts-expect-error missing API
       app.uploadData(json)

--- a/packages/devtools/src/server-rpc/analyze-build.ts
+++ b/packages/devtools/src/server-rpc/analyze-build.ts
@@ -9,7 +9,7 @@ import { glob } from 'tinyglobby'
 
 const COLON_RE = /:/g
 
-export function setupAnalyzeBuildRPC({ nuxt, refresh, ensureDevAuthToken }: NuxtDevtoolsServerContext) {
+export function setupAnalyzeBuildRPC({ nuxt, refresh }: NuxtDevtoolsServerContext) {
   let builds: AnalyzeBuildMeta[] = []
   let promise: Promise<any> | undefined
   let initalized: Promise<any> | undefined
@@ -118,9 +118,7 @@ export function setupAnalyzeBuildRPC({ nuxt, refresh, ensureDevAuthToken }: Nuxt
         builds,
       }
     },
-    async clearAnalyzeBuilds(token: string, names?: string[]) {
-      await ensureDevAuthToken(token)
-
+    async clearAnalyzeBuilds(names?: string[]) {
       if (!names) {
         await fsp.rm(devtoolsAnalyzeDir, { recursive: true, force: true })
       }
@@ -132,8 +130,7 @@ export function setupAnalyzeBuildRPC({ nuxt, refresh, ensureDevAuthToken }: Nuxt
       refresh('getAnalyzeBuildInfo')
     },
     generateAnalyzeBuildName,
-    async startAnalyzeBuild(token: string, ...args) {
-      await ensureDevAuthToken(token)
+    async startAnalyzeBuild(...args) {
       return startAnalyzeBuild(...args)
     },
   } satisfies Partial<ServerFunctions>

--- a/packages/devtools/src/server-rpc/assets.ts
+++ b/packages/devtools/src/server-rpc/assets.ts
@@ -7,7 +7,7 @@ import { debounce } from 'perfect-debounce'
 import { glob } from 'tinyglobby'
 import { defaultAllowedExtensions } from '../constant'
 
-export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: NuxtDevtoolsServerContext) {
+export function setupAssetsRPC({ nuxt, refresh, options }: NuxtDevtoolsServerContext) {
   const _imageMetaCache = new Map<string, ImageMeta | undefined>()
   let cache: AssetInfo[] | null = null
 
@@ -75,9 +75,7 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
     async getStaticAssets() {
       return await scan()
     },
-    async getImageMeta(token: string, filepath: string) {
-      await ensureDevAuthToken(token)
-
+    async getImageMeta(filepath: string) {
       if (_imageMetaCache.has(filepath))
         return _imageMetaCache.get(filepath)
       try {
@@ -91,9 +89,7 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
         return undefined
       }
     },
-    async getTextAssetContent(token: string, filepath: string, limit = 300) {
-      await ensureDevAuthToken(token)
-
+    async getTextAssetContent(filepath: string, limit = 300) {
       try {
         const content = await fsp.readFile(filepath, 'utf-8')
         return content.slice(0, limit)
@@ -103,9 +99,7 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
         return undefined
       }
     },
-    async writeStaticAssets(token: string, files: AssetEntry[], folder: string) {
-      await ensureDevAuthToken(token)
-
+    async writeStaticAssets(files: AssetEntry[], folder: string) {
       const baseDir = resolve(nuxt.options.srcDir, nuxt.options.dir.public + folder)
 
       return await Promise.all(
@@ -140,14 +134,10 @@ export function setupAssetsRPC({ nuxt, ensureDevAuthToken, refresh, options }: N
         }),
       )
     },
-    async deleteStaticAsset(token: string, path: string) {
-      await ensureDevAuthToken(token)
-
+    async deleteStaticAsset(path: string) {
       return await fsp.unlink(path)
     },
-    async renameStaticAsset(token: string, oldPath: string, newPath: string) {
-      await ensureDevAuthToken(token)
-
+    async renameStaticAsset(oldPath: string, newPath: string) {
       const exist = cache?.find(asset => asset.filePath === newPath)
       if (exist)
         throw new Error(`[Nuxt DevTools] File ${newPath} already exists, failed to rename`)

--- a/packages/devtools/src/server-rpc/general.ts
+++ b/packages/devtools/src/server-rpc/general.ts
@@ -23,7 +23,6 @@ export function setupGeneralRPC({
   nuxt,
   options,
   refresh,
-  ensureDevAuthToken,
   openInEditorHooks,
 }: NuxtDevtoolsServerContext) {
   const components: Component[] = []
@@ -232,9 +231,7 @@ export function setupGeneralRPC({
         return false
       }
     },
-    async enablePages(token: string) {
-      await ensureDevAuthToken(token)
-
+    async enablePages() {
       const baseDir = nuxt.options.future.compatibilityVersion === 4 ? nuxt.options.dir.app : nuxt.options.srcDir
       const pathApp = join(baseDir, 'app.vue')
       const pathPageIndex = join(baseDir, 'pages/index.vue')
@@ -262,8 +259,7 @@ export function setupGeneralRPC({
 
       logger.success('Routing creation completed')
     },
-    async restartNuxt(token: string, hard = true) {
-      await ensureDevAuthToken(token)
+    async restartNuxt(hard = true) {
       logger.info('Restarting Nuxt...')
       return nuxt.callHook('restart', { hard })
     },

--- a/packages/devtools/src/server-rpc/index.ts
+++ b/packages/devtools/src/server-rpc/index.ts
@@ -109,10 +109,6 @@ export function setupRPC(nuxt: Nuxt, options: ModuleOptions) {
     refresh,
     extendServerRpc,
     openInEditorHooks: [],
-    /** @deprecated Auth is now handled by Vite DevTools */
-    async ensureDevAuthToken(_token: string) {
-      logger.warn('[nuxt-devtools] `ensureDevAuthToken` is deprecated. Auth is now handled by Vite DevTools.')
-    },
   }
 
   // @ts-expect-error untyped

--- a/packages/devtools/src/server-rpc/npm.ts
+++ b/packages/devtools/src/server-rpc/npm.ts
@@ -8,7 +8,7 @@ import { detect } from 'package-manager-detector/detect'
 import { checkForUpdateOf } from '../npm'
 import { magicastGuard } from '../utils/magicast'
 
-export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerContext) {
+export function setupNpmRPC({ nuxt }: NuxtDevtoolsServerContext) {
   let detectPromise: Promise<DetectResult | null> | undefined
   const updatesPromise = new Map<string, Promise<PackageUpdateInfo | undefined>>()
 
@@ -78,13 +78,10 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
       return updatesPromise.get(name)!
     },
     getNpmCommand,
-    async runNpmCommand(token, ...args) {
-      await ensureDevAuthToken(token)
+    async runNpmCommand(...args) {
       return runNpmCommand(...args)
     },
-    async installNuxtModule(token: string, name: string, dry = true) {
-      await ensureDevAuthToken(token)
-
+    async installNuxtModule(name: string, dry = true) {
       const commands = (await getNpmCommand('install', name, { dev: true }))!
 
       const filepath = nuxt.options._nuxtConfigFile
@@ -142,9 +139,7 @@ export function setupNpmRPC({ nuxt, ensureDevAuthToken }: NuxtDevtoolsServerCont
         processId,
       }
     },
-    async uninstallNuxtModule(token: string, name: string, dry = true) {
-      await ensureDevAuthToken(token)
-
+    async uninstallNuxtModule(name: string, dry = true) {
       const commands = (await getNpmCommand('uninstall', name))!
 
       const filepath = nuxt.options._nuxtConfigFile

--- a/packages/devtools/src/server-rpc/server-data.ts
+++ b/packages/devtools/src/server-rpc/server-data.ts
@@ -5,7 +5,6 @@ import { addVitePlugin } from '@nuxt/kit'
 
 export function setupServerDataRPC({
   nuxt,
-  ensureDevAuthToken,
 }: NuxtDevtoolsServerContext) {
   let nitro: Nitro | undefined
   let viteServer: ResolvedConfig | undefined
@@ -61,8 +60,7 @@ export function setupServerDataRPC({
     getServerConfig() {
       return nuxt.options
     },
-    async getServerData(token: string) {
-      await ensureDevAuthToken(token)
+    async getServerData() {
       return {
         nuxt: nuxt.options,
         nitro: nitro?.options,

--- a/packages/devtools/src/server-rpc/storage.ts
+++ b/packages/devtools/src/server-rpc/storage.ts
@@ -11,7 +11,6 @@ function shouldIgnoreStorageKey(key: string) {
 export function setupStorageRPC({
   nuxt,
   rpc,
-  ensureDevAuthToken,
 }: NuxtDevtoolsServerContext) {
   const storageMounts: StorageMounts = {}
 
@@ -71,20 +70,17 @@ export function setupStorageRPC({
         return []
       }
     },
-    async getStorageItem(token: string, key: string) {
-      await ensureDevAuthToken(token)
+    async getStorageItem(key: string) {
       if (!storage)
         return null
       return await storage.getItem(key)
     },
-    async setStorageItem(token: string, key: string, value: StorageValue) {
-      await ensureDevAuthToken(token)
+    async setStorageItem(key: string, value: StorageValue) {
       if (!storage)
         return
       return await storage.setItem(key, value)
     },
-    async removeStorageItem(token: string, key: string) {
-      await ensureDevAuthToken(token)
+    async removeStorageItem(key: string) {
       if (!storage)
         return
       return await storage.removeItem(key)

--- a/packages/devtools/src/server-rpc/terminals.ts
+++ b/packages/devtools/src/server-rpc/terminals.ts
@@ -1,6 +1,6 @@
 import type { NuxtDevtoolsServerContext, ServerFunctions, TerminalAction, TerminalInfo, TerminalState } from '../types'
 
-export function setupTerminalRPC({ nuxt, rpc, refresh, ensureDevAuthToken }: NuxtDevtoolsServerContext) {
+export function setupTerminalRPC({ nuxt, rpc, refresh }: NuxtDevtoolsServerContext) {
   const terminals = new Map<string, TerminalState>()
 
   nuxt.hook('devtools:terminal:register', (terminal) => {
@@ -62,12 +62,10 @@ export function setupTerminalRPC({ nuxt, rpc, refresh, ensureDevAuthToken }: Nux
     getTerminals() {
       return Array.from(terminals.values(), i => serializeTerminal(i))
     },
-    async getTerminalDetail(token: string, id: string) {
-      await ensureDevAuthToken(token)
+    async getTerminalDetail(id: string) {
       return serializeTerminal(terminals.get(id), true)
     },
-    async runTerminalAction(token: string, id: string, action: TerminalAction) {
-      await ensureDevAuthToken(token)
+    async runTerminalAction(id: string, action: TerminalAction) {
       const terminal = terminals.get(id)
       if (!terminal)
         return false


### PR DESCRIPTION
## Summary

- Remove the `token: string` parameter from all 18 builtin RPC function signatures in `ServerFunctions` interface
- Remove `ensureDevAuthToken` calls from all server RPC implementations (7 files) and from the server context
- Remove token arguments from all client-side RPC call sites (12 files) and clean up unused imports
- Remove `ensureDevAuthToken` export from the client `dev-auth` composable

Auth is now handled by Vite DevTools, so these token parameters were deprecated noops that only logged warnings.

## Test plan

- [ ] Verify `pnpm typecheck` passes
- [ ] Verify devtools client loads and RPC functions work without token args

🤖 Generated with [Claude Code](https://claude.com/claude-code)