### PR TITLE
build: fix build order

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
+      "dependsOn": [
+        "^build"
+      ],
       "outputLogs": "new-only",
       "outputs": [
         "dist/**"


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/devtools/actions/runs/24111824283/job/70347835615
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description


Seems like turbo is running step for all packages in parallel but devtools requires devtools-kit to be built first
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
