### PR TITLE
fix(devtools): pre-bundle additional injected client deps in dev

### DIFF
--- a/packages/devtools/src/module-main.ts
+++ b/packages/devtools/src/module-main.ts
@@ -64,8 +64,14 @@ export async function enableModule(options: ModuleOptions, nuxt: Nuxt) {
   if (nuxt.options.dev) {
     nuxt.options.vite.optimizeDeps ||= {}
     nuxt.options.vite.optimizeDeps.include ||= []
-    nuxt.options.vite.optimizeDeps.include.push('@vue/devtools-kit')
-    nuxt.options.vite.optimizeDeps.include.push('@vue/devtools-core')
+    nuxt.options.vite.optimizeDeps.include.push(
+      '@vue/devtools-kit',
+      '@vue/devtools-core',
+      '@vitejs/devtools/client/inject',
+      '@vitejs/devtools-kit/client',
+      'error-stack-parser-es',
+      'vite-plugin-vue-tracer/client/overlay',
+    )
   }
 
   const DevTools = await import('@vitejs/devtools').then(r => r.DevTools())


### PR DESCRIPTION
## Summary

Extends the existing dev `optimizeDeps.include` block in `module-main.ts` so Vite stops triggering a page reload when it discovers the deps imported by the injected runtime client plugins. Adds `@vitejs/devtools/client/inject`, `@vitejs/devtools-kit/client`, `error-stack-parser-es`, and `vite-plugin-vue-tracer/client/overlay` to the list that already had `@vue/devtools-kit` and `@vue/devtools-core` (originally added under #980/#981). All four are already direct deps of `@nuxt/devtools`.

## Test plan
- [ ] `pnpm -C playgrounds/empty exec nuxt dev` — confirm the "Pre-bundle them in your nuxt.config.ts" warning listing those packages no longer appears
- [ ] Same check for `playgrounds/tab-pinia` and `playgrounds/tab-seo`
- [ ] e2e suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)