### PR TITLE
feat: add Google Antigravity support

### DIFF
--- a/packages/devtools-kit/src/_types/rpc.ts
+++ b/packages/devtools-kit/src/_types/rpc.ts
@@ -82,6 +82,7 @@ export interface ClientFunctions {
   refresh: (event: ClientUpdateEvent) => void
   callHook: (hook: string, ...args: any[]) => Promise<void>
   navigateTo: (path: string) => void
+  openUrl: (url: string) => void
 
   onTerminalData: (_: { id: string, data: string }) => void
   onTerminalExit: (_: { id: string, code?: number }) => void

--- a/packages/devtools/client/pages/settings.vue
+++ b/packages/devtools/client/pages/settings.vue
@@ -39,6 +39,7 @@ const editorOptions = [
   ['Sublime Text', 'sublime'],
   ['Atom', 'atom'],
   ['Windsurf', 'windsurf'],
+  ['Google Antigravity', 'antigravity'],
 ]
 
 const scaleOptions = [

--- a/packages/devtools/client/setup/client-rpc.ts
+++ b/packages/devtools/client/setup/client-rpc.ts
@@ -40,6 +40,9 @@ export function setupClientRPC() {
       if (router.currentRoute.value?.path !== path)
         router.push(path)
     },
+    async openUrl(url: string) {
+      window.open(url, '_blank')
+    },
   } satisfies ClientFunctions)
 
   // Re-register client functions now that they're populated

--- a/packages/devtools/src/server-rpc/general.ts
+++ b/packages/devtools/src/server-rpc/general.ts
@@ -19,12 +19,8 @@ const ABSOLUTE_PATH_RE = /^[a-z]:|^\//i
 const FILE_LINE_COL_RE = /^(.*?)(:[:\d]*)$/
 const NUXT_WELCOME_RE = /<NuxtWelcome\s*\/>/
 
-export function setupGeneralRPC({
-  nuxt,
-  options,
-  refresh,
-  openInEditorHooks,
-}: NuxtDevtoolsServerContext) {
+export function setupGeneralRPC(ctx: NuxtDevtoolsServerContext) {
+  const { nuxt, options, refresh, openInEditorHooks } = ctx
   const components: Component[] = []
   const imports: Import[] = []
   const importPresets: Import[] = []
@@ -223,6 +219,10 @@ export function setupGeneralRPC({
         let editor = getOptions()?.behavior.openInEditor ?? undefined
         if (editor === 'auto')
           editor = undefined
+        if (editor === 'antigravity') {
+          ctx.rpc.broadcast.openUrl(`https://antigravity.google/open?file=${path}${suffix}`)
+          return true
+        }
         await import('launch-editor').then(r => (r.default || r)(path + suffix, editor))
         return true
       }


### PR DESCRIPTION
Resolves #987

### Description
This PR adds support for Google Antigravity as a selectable code editor in Nuxt DevTools. 

Since Antigravity is a browser-based IDE, it cannot use standard CLI spawn commands (which results in an `ENOENT` error when using `launch-editor`). To solve this, this implementation intercepts the `openInEditor` request on the server if `antigravity` is selected, and instead broadcasts an `openUrl` event to the client to handle the navigation via the browser.

### Changes
*   Added `antigravity` to the editor options in `settings.vue`.
*   Added `openUrl` to `ClientFunctions` RPC types.
*   Implemented `openUrl` in `client-rpc.ts` using `window.open`.
*   Refactored `setupGeneralRPC` slightly to access `ctx.rpc.broadcast` and handle the Antigravity URL scheme bypassing `launch-editor`.

