### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nuxt/devtools-docs",
   "private": true,
-  "packageManager": "pnpm@10.32.1",
+  "packageManager": "pnpm@11.1.3",
   "scripts": {
     "dev": "nuxi dev",
     "build": "nuxi build",

--- a/docs/pnpm-workspace.yaml
+++ b/docs/pnpm-workspace.yaml
@@ -18,10 +18,10 @@ catalog:
   better-sqlite3: ^12.8.0
   nuxt: ^4.4.2
   nuxt-og-image: ^6.0.3
-onlyBuiltDependencies:
-  - better-sqlite3
-  - esbuild
-  - sharp
-  - vue-demi
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  sharp: true
+  vue-demi: true
 shamefullyHoist: true
 strictPeerDependencies: false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "4.0.0-alpha.4",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.1.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nuxt/devtools.git"
@@ -62,17 +62,6 @@
     "unocss": "catalog:buildtools",
     "vite-hot-client": "catalog:frontend",
     "vue": "catalog:frontend",
-    "vue-tsc": "catalog:cli"
-  },
-  "resolutions": {
-    "@nuxt/devtools": "workspace:*",
-    "chokidar": "catalog:buildtools",
-    "esbuild": "catalog:buildtools",
-    "rollup": "catalog:buildtools",
-    "semver": "catalog:prod",
-    "typescript": "catalog:cli",
-    "unimport": "catalog:types",
-    "vite": "catalog:buildtools",
     "vue-tsc": "catalog:cli"
   },
   "simple-git-hooks": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,26 @@ packages:
   - packages/**
   - playgrounds/**
 
+allowBuilds:
+  '@parcel/watcher': true
+  better-sqlite3: true
+  cypress: true
+  esbuild: true
+  json-editor-vue: true
+  simple-git-hooks: true
+  unrs-resolver: true
+  vue-demi: true
+
+overrides:
+  '@nuxt/devtools': workspace:*
+  chokidar: catalog:buildtools
+  esbuild: catalog:buildtools
+  rollup: catalog:buildtools
+  semver: catalog:prod
+  typescript: catalog:cli
+  unimport: catalog:types
+  vite: catalog:buildtools
+  vue-tsc: catalog:cli
 catalogs:
   buildtools:
     '@discoveryjs/cli': ^2.14.7
@@ -147,12 +167,3 @@ catalogs:
     '@unhead/schema': ^2.1.13
     '@vitejs/devtools-kit': ^0.1.13
     unimport: ^6.0.2
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - better-sqlite3
-  - cypress
-  - esbuild
-  - json-editor-vue
-  - simple-git-hooks
-  - unrs-resolver
-  - vue-demi


### PR DESCRIPTION
## Summary

- Bumps `packageManager` to `pnpm@11.1.3` in the root and `docs/` workspace.
- Migrates `pnpm-workspace.yaml` to v11's new shape: `onlyBuiltDependencies` (array) → `allowBuilds` (map), and moves `resolutions` out of `package.json` into an `overrides:` section (v11 no longer reads settings from `package.json`).
- `pnpm-lock.yaml` is unchanged — no dependency churn.

## Test plan

- [x] `pnpm install` (fresh)
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm typecheck`