### PR TITLE
fix(devtools): reference optimizeDeps in reference to `@nuxt/devtools`

### DIFF
--- a/packages/devtools/src/module-main.ts
+++ b/packages/devtools/src/module-main.ts
@@ -65,12 +65,12 @@ export async function enableModule(options: ModuleOptions, nuxt: Nuxt) {
     nuxt.options.vite.optimizeDeps ||= {}
     nuxt.options.vite.optimizeDeps.include ||= []
     nuxt.options.vite.optimizeDeps.include.push(
-      '@vue/devtools-kit',
-      '@vue/devtools-core',
-      '@vitejs/devtools/client/inject',
-      '@vitejs/devtools-kit/client',
-      'error-stack-parser-es',
-      'vite-plugin-vue-tracer/client/overlay',
+      'nuxt > @nuxt/devtools > @vue/devtools-kit',
+      'nuxt > @nuxt/devtools > @vue/devtools-core',
+      'nuxt > @nuxt/devtools > @vitejs/devtools/client/inject',
+      'nuxt > @nuxt/devtools > @vitejs/devtools-kit/client',
+      'nuxt > @nuxt/devtools > error-stack-parser-es',
+      'nuxt > @nuxt/devtools > vite-plugin-vue-tracer/client/overlay',
     )
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/devtools/issues/980
https://github.com/nuxt/devtools/issues/981

### 📚 Description

trying this out on the nuxt main branch, we got some warnings:

```
Unresolvable optimizeDeps.include entries:
  @vue/devtools-kit
  @vue/devtools-core
```

that's because these aren't direct dependencies of users' projects and won't be resolvable with pnpm, so I switch to using the nested path (`nuxt > @nuxt/devtools > *`)

another alternative might simply be to fully resolve the paths so we don't care about the dependency chain - wdyt?