### PR TITLE
fix(devtools): proper XDG base dir support

### DIFF
--- a/packages/devtools/src/dev-auth.ts
+++ b/packages/devtools/src/dev-auth.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import { join } from 'node:path'
 import { randomStr } from '@antfu/utils'
-import { getHomeDir } from './utils/local-options'
+import { getOptionsDir } from './utils/local-options'
 
 let token: string | undefined
 
@@ -10,8 +10,7 @@ export async function getDevAuthToken() {
   if (token)
     return token
 
-  const home = getHomeDir()
-  const dir = join(home, '.nuxt/devtools')
+  const dir = getOptionsDir()
   const filepath = join(dir, 'dev-auth-token.txt')
 
   if (existsSync(filepath))

--- a/packages/devtools/src/utils/local-options.ts
+++ b/packages/devtools/src/utils/local-options.ts
@@ -56,7 +56,7 @@ function getOptionsFilepath(options: LocalOptionSearchOptions) {
     hashedKey = hash(options.root)
 
   const dir = getOptionsDir()
-  const filePath = join(dir, '.nuxt/devtools', `${hashedKey}.json`)
+  const filePath = join(dir, `${hashedKey}.json`)
 
   return {
     filePath,

--- a/packages/devtools/src/utils/local-options.ts
+++ b/packages/devtools/src/utils/local-options.ts
@@ -21,7 +21,7 @@ export function getOptionsDir() {
 
   // https://specifications.freedesktop.org/basedir/latest/#variables
   // Check if env var is set, otherwise fallback to $HOME/.config
-  const xdgBase = process.env.XDG_CONFIG_HOME ?? join(home, '.config')
+  const xdgBase = process.env.XDG_CONFIG_HOME || join(home, '.config')
   return join(xdgBase, 'nuxt/devtools')
 }
 

--- a/packages/devtools/src/utils/local-options.ts
+++ b/packages/devtools/src/utils/local-options.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
-import { homedir } from 'node:os'
+import { homedir, platform } from 'node:os'
 import { dirname } from 'node:path'
 import { hash } from 'ohash'
 import { join } from 'pathe'
@@ -10,8 +10,19 @@ interface LocalOptionSearchOptions {
   key?: string | boolean
 }
 
-export function getHomeDir() {
-  return process.env.XDG_CONFIG_HOME || homedir()
+export function getOptionsDir() {
+  const home = homedir()
+  const osPlatform = platform()
+
+  // From research, there three are not trying to be XDG compliant. Leave it as before
+  if (osPlatform === 'win32' || osPlatform === 'darwin' || osPlatform === 'haiku') {
+    return join(home, '.nuxt/devtools')
+  }
+
+  // https://specifications.freedesktop.org/basedir/latest/#variables
+  // Check if env var is set, otherwise fallback to $HOME/.config
+  const xdgBase = process.env.XDG_CONFIG_HOME ?? join(home, '.config')
+  return join(xdgBase, 'nuxt/devtools')
 }
 
 export async function readLocalOptions<T>(defaults: T, options: LocalOptionSearchOptions): Promise<T> {
@@ -44,8 +55,8 @@ function getOptionsFilepath(options: LocalOptionSearchOptions) {
   else
     hashedKey = hash(options.root)
 
-  const home = getHomeDir()
-  const filePath = join(home, '.nuxt/devtools', `${hashedKey}.json`)
+  const dir = getOptionsDir()
+  const filePath = join(dir, '.nuxt/devtools', `${hashedKey}.json`)
 
   return {
     filePath,


### PR DESCRIPTION
### 🔗 Linked issue

resolves #915 

### 📚 Description

The problem with the current implementation is it fallback to the wrong place. Per [the XDG specfication](https://specifications.freedesktop.org/basedir/latest/#variables):

> If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used. 

Also since the directory is now correctly set, we can remove the dot prefix following other convention
