### PR TITLE
chore: replace `npm` to `npmx`

### DIFF
--- a/docs/content/1.guide/1.features.md
+++ b/docs/content/1.guide/1.features.md
@@ -106,7 +106,7 @@ The source is live: every query reads the current state, so re-running a query a
 
 The panel's bundled UI includes an optional polling toggle (5s default, clamped 1–3600s) that pauses in background tabs.
 
-Module authors who want to expose their own data can install [`@devframes/plugin-data-inspector`](https://www.npmjs.com/package/@devframes/plugin-data-inspector) and register sources through its `registerDataSource` API; they appear in the same inspector without any Nuxt-specific wrapper.
+Module authors who want to expose their own data can install [`@devframes/plugin-data-inspector`](https://npmx.dev/package/@devframes/plugin-data-inspector) and register sources through its `registerDataSource` API; they appear in the same inspector without any Nuxt-specific wrapper.
 
 ::warning
 The `getServerData` DevTools RPC that backed the old viewer is deprecated (`NDT_DEP_0009`). It still works as a compatibility shim but will be removed; use the Data Inspector panel instead.

--- a/docs/content/2.module/3.migration-v4.md
+++ b/docs/content/2.module/3.migration-v4.md
@@ -249,7 +249,7 @@ The read-only **Nuxt Options Viewer** page has been replaced by the [Data Inspec
 
 The `getServerData` server RPC that fed the old page is deprecated (`NDT_DEP_0009`). It still works as a compatibility shim — returning the legacy `NuxtServerData` shape (`{ nuxt, nitro, vite: { server, client } }`) with the Vite configs normalized for transport — but emits the diagnostic on first use and will be removed in a future major. Query the Data Inspector's `Nuxt Application` source instead of calling the RPC.
 
-To expose your own inspectable data, install [`@devframes/plugin-data-inspector`](https://www.npmjs.com/package/@devframes/plugin-data-inspector) and register a source through its native `registerDataSource` API; there is no Nuxt-specific wrapper.
+To expose your own inspectable data, install [`@devframes/plugin-data-inspector`](https://npmx.dev/package/@devframes/plugin-data-inspector) and register a source through its native `registerDataSource` API; there is no Nuxt-specific wrapper.
 
 ## Global Install Support Removed
 

--- a/packages/devtools-ui-kit/README.md
+++ b/packages/devtools-ui-kit/README.md
@@ -1,6 +1,6 @@
 # @nuxt/devtools-ui-kit
 
-<a href="https://www.npmjs.com/package/@nuxt/devtools-ui-kit"><img src="https://flat.badgen.net/npm/v/@nuxt/devtools-ui-kit" alt="npm version"></a>
+<a href="https://npmx.dev/package/@nuxt/devtools-ui-kit"><img src="https://flat.badgen.net/npm/v/@nuxt/devtools-ui-kit" alt="npm version"></a>
 
 > **Deprecated**: This package is deprecated and no longer recommended for new integrations. It is kept around for existing consumers, but should not be adopted going forward.
 

--- a/packages/devtools/client/components/ModuleItemBase.vue
+++ b/packages/devtools/client/components/ModuleItemBase.vue
@@ -24,7 +24,7 @@ const data = computed(() => ({
 const iconBase = 'https://ipx.nuxt.com/s_80,f_webp/gh/nuxt/modules/main/icons/'
 const avatarBase = 'https://ipx.nuxt.com/s_44,f_webp/gh_avatar/'
 const githubBase = 'https://github.com/'
-const npmBase = 'https://www.npmjs.com/package/'
+const npmxBase = 'https://npmx.dev/package/'
 
 const { format: formatNumber } = Intl.NumberFormat(navigator.language || 'en', { notation: 'compact', maximumFractionDigits: 1 })
 
@@ -41,7 +41,7 @@ const openInEditor = useOpenInEditor()
         <div gap-1t flex items-center text-ellipsis ws-nowrap text-lg>
           <NuxtLink
             v-if="mod.isPackageModule"
-            :to="npmBase + (data.npm || data.name)"
+            :to="npmxBase + (data.npm || data.name)"
             target="_blank"
             hover="underline text-primary"
           >


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Use npmx links to display npm packages.
